### PR TITLE
Finish implementing Dynamic Registration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,3 +26,9 @@
 
 /.scannerwork/
 /sonar-project.properties
+
+# Locally generated certificates
+*.key
+*.pem
+*.crt
+*.p12

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
-        <version>2.4.5</version>
+        <version>2.6.2</version>
         <relativePath/> <!-- lookup parent from repository -->
     </parent>
     <groupId>net.unicon</groupId>

--- a/src/main/java/net/unicon/lti/controller/lti/OIDCController.java
+++ b/src/main/java/net/unicon/lti/controller/lti/OIDCController.java
@@ -205,7 +205,7 @@ public class OIDCController {
         authRequestMap.put("nonce", nonce);  //The nonce
         authRequestMap.put("nonce_hash", nonceHash);  //The hash value of the nonce
         authRequestMap.put("prompt", NONE);  //Always this value, as specified in the standard.
-        authRequestMap.put("redirect_uri", ltiDataService.getLocalUrl() + "/lti3");  // One of the valids reditect uris.
+        authRequestMap.put("redirect_uri", ltiDataService.getLocalUrl() + TextConstants.LTI3_SUFFIX);  // One of the valids reditect uris.
         authRequestMap.put("response_mode", FORM_POST); //Always this value, as specified in the standard.
         authRequestMap.put("response_type", ID_TOKEN); //Always this value, as specified in the standard.
         authRequestMap.put("scope", OPEN_ID);  //Always this value, as specified in the standard.

--- a/src/main/java/net/unicon/lti/controller/lti/RegistrationController.java
+++ b/src/main/java/net/unicon/lti/controller/lti/RegistrationController.java
@@ -12,25 +12,24 @@
  */
 package net.unicon.lti.controller.lti;
 
+import lombok.extern.slf4j.Slf4j;
 import net.unicon.lti.exceptions.ConnectionException;
 import net.unicon.lti.model.lti.dto.PlatformRegistrationDTO;
 import net.unicon.lti.model.lti.dto.ToolConfigurationDTO;
 import net.unicon.lti.model.lti.dto.ToolMessagesSupportedDTO;
 import net.unicon.lti.model.lti.dto.ToolRegistrationDTO;
 import net.unicon.lti.repository.PlatformDeploymentRepository;
-import net.unicon.lti.service.lti.LTIDataService;
 import net.unicon.lti.service.lti.RegistrationService;
 import net.unicon.lti.utils.LtiStrings;
 import net.unicon.lti.utils.TextConstants;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import org.apache.commons.lang3.StringUtils;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnExpression;
 import org.springframework.context.annotation.Scope;
 import org.springframework.http.HttpEntity;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpMethod;
-import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.http.client.BufferingClientHttpRequestFactory;
 import org.springframework.http.client.SimpleClientHttpRequestFactory;
@@ -39,7 +38,9 @@ import org.springframework.ui.Model;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestMethod;
 import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.client.HttpServerErrorException;
 import org.springframework.web.client.RestTemplate;
+import org.springframework.web.util.DefaultUriBuilderFactory;
 
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpSession;
@@ -47,7 +48,9 @@ import java.io.UnsupportedEncodingException;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.LinkedHashSet;
 import java.util.List;
+import java.util.Set;
 
 /**
  * This LTI controller should be protected by OAuth 1.0a (on the /oauth path)
@@ -55,31 +58,34 @@ import java.util.List;
  * Sample Key "key" and secret "secret"
  */
 @SuppressWarnings("ALL")
+@Slf4j
 @Controller
 @Scope("session")
 @RequestMapping("/registration")
+@ConditionalOnExpression("${lti13.enableDynamicRegistration}")
 public class RegistrationController {
-
-    static final Logger log = LoggerFactory.getLogger(RegistrationController.class);
-
     @Autowired
     PlatformDeploymentRepository platformDeploymentRepository;
 
     @Autowired
-    LTIDataService ltiDataService;
-
-    @Autowired
     RegistrationService registrationService;
+
+    private RestTemplate restTemplate;
 
     @Value("${application.url}")
     private String localUrl;
 
+    @Value("${domain.url}")
+    private String domainUrl;
 
     @Value("${application.name}")
     private String clientName;
 
     @Value("${application.description}")
     private String description;
+
+    @Value("${lti13.demoMode}")
+    private boolean demoMode;
 
 
     /**
@@ -94,65 +100,70 @@ public class RegistrationController {
      * @param model
      * @return
      */
-    @RequestMapping(value = "/", method = RequestMethod.GET)
-    public String registration(@RequestParam("openid_configuration") String openidConfiguration, @RequestParam(LtiStrings.REGISTRATION_TOKEN) String registrationToken, HttpServletRequest req, Model model) {
-
+    @RequestMapping(value = {"", "/"}, method = RequestMethod.GET)
+    public String registration(@RequestParam("openid_configuration") String openidConfiguration, @RequestParam(name = LtiStrings.REGISTRATION_TOKEN, required = false) String registrationToken, HttpServletRequest req, Model model) {
         // We need to call the configuration endpoint recevied in the registration inititaion message and
         // call it to get all the information about the platform
         HttpSession session = req.getSession();
-        model.addAttribute("openid_configuration", openidConfiguration);
+        log.debug(openidConfiguration);
         session.setAttribute(LtiStrings.REGISTRATION_TOKEN, registrationToken);
-        model.addAttribute(LtiStrings.REGISTRATION_TOKEN, registrationToken);
-        model.addAttribute("own_redirect_post_endpoint", localUrl + "/registration/");
 
         try {
             // We are going to create the call the openidconfiguration endpoint,
-            RestTemplate restTemplate = new RestTemplate(
-                    new BufferingClientHttpRequestFactory(new SimpleClientHttpRequestFactory()));
+            restTemplate = restTemplate == null ? new RestTemplate(new BufferingClientHttpRequestFactory(new SimpleClientHttpRequestFactory())) : restTemplate;
 
             //The URL to get the course contents is stored in the context (in our database) because it came
             // from the platform when we created the link to the context, and we saved it then.
 
+            HttpHeaders headers = new HttpHeaders();
+            DefaultUriBuilderFactory defaultUriBuilderFactory = new DefaultUriBuilderFactory();
+            defaultUriBuilderFactory.setEncodingMode(DefaultUriBuilderFactory.EncodingMode.NONE);
+            restTemplate.setUriTemplateHandler(defaultUriBuilderFactory);
             ResponseEntity<PlatformRegistrationDTO> platformConfiguration = restTemplate.
-                    exchange(openidConfiguration, HttpMethod.GET, new HttpEntity<>(new HttpHeaders()), PlatformRegistrationDTO.class);
+                    exchange(openidConfiguration, HttpMethod.GET, new HttpEntity<>(headers), PlatformRegistrationDTO.class);
             PlatformRegistrationDTO platformRegistrationDTO = null;
-            if (platformConfiguration != null) {
-                HttpStatus status = platformConfiguration.getStatusCode();
-                if (status.is2xxSuccessful()) {
-                    platformRegistrationDTO = platformConfiguration.getBody();
-                } else {
-                    String exceptionMsg = "Can't get the platform configuration";
-                    log.error(exceptionMsg);
-                    throw new ConnectionException(exceptionMsg);
-                }
+            if (platformConfiguration != null && platformConfiguration.getStatusCode().is2xxSuccessful() && platformConfiguration.getBody() != null) {
+                platformRegistrationDTO = platformConfiguration.getBody();
             } else {
-                log.warn("Problem getting the membership");
+                String exceptionMsg = "Can't get the platform configuration";
+                log.error(exceptionMsg);
+                throw new ConnectionException(exceptionMsg);
             }
-            model.addAttribute(LtiStrings.PLATFORM_CONFIGURATION, platformRegistrationDTO);
-
 
             session.setAttribute(LtiStrings.PLATFORM_CONFIGURATION, platformRegistrationDTO);
-            ToolRegistrationDTO toolRegistrationDTO = generateToolConfiguration();
-            // We add that information so the thymeleaf template can display it (and prepare the links)
-            model.addAttribute(LtiStrings.TOOL_CONFIGURATION, toolRegistrationDTO);
+            ToolRegistrationDTO toolRegistrationDTO = generateToolConfiguration(platformConfiguration.getBody());
             session.setAttribute(LtiStrings.TOOL_CONFIGURATION, toolRegistrationDTO);
 
             // Once all is added to the session, and we have the data ready for the html template, we redirect
-            return "registrationRedirect";
-        } catch (Exception ex) {
+            if (!demoMode) {
+                return registrationPOST(req, model, registrationToken, platformRegistrationDTO, toolRegistrationDTO);
+            } else {
+                model.addAttribute("openid_configuration", openidConfiguration);
+                model.addAttribute(LtiStrings.REGISTRATION_TOKEN, registrationToken);
+                model.addAttribute("own_redirect_post_endpoint", localUrl + "/registration/");
+                model.addAttribute(LtiStrings.PLATFORM_CONFIGURATION, platformRegistrationDTO);
+                model.addAttribute(LtiStrings.TOOL_CONFIGURATION, toolRegistrationDTO);
+
+                return "registrationRedirect";
+            }
+        } catch (HttpServerErrorException | ConnectionException ex) {
+            ex.printStackTrace();
             model.addAttribute("Error", ex.getMessage());
             return "registrationError";
         }
     }
 
     @RequestMapping(value = "/", method = RequestMethod.POST)
-    public String registrationPOST(HttpServletRequest req,
-                                   Model model) {
+    public String registrationPOST(HttpServletRequest req, Model model) {
         HttpSession session = req.getSession();
         String token = (String) session.getAttribute(LtiStrings.REGISTRATION_TOKEN);
         PlatformRegistrationDTO platformRegistrationDTO = (PlatformRegistrationDTO) session.getAttribute(LtiStrings.PLATFORM_CONFIGURATION);
         ToolRegistrationDTO toolRegistrationDTO = (ToolRegistrationDTO) session.getAttribute(LtiStrings.TOOL_CONFIGURATION);
 
+        return registrationPOST(req, model, token, platformRegistrationDTO, toolRegistrationDTO);
+    }
+
+    private String registrationPOST(HttpServletRequest req, Model model, String token, PlatformRegistrationDTO platformRegistrationDTO, ToolRegistrationDTO toolRegistrationDTO) {
         String answer = "Error during the registration";
         try {
             answer = registrationService.callDynamicRegistration(token, toolRegistrationDTO, platformRegistrationDTO.getRegistration_endpoint());
@@ -165,9 +176,12 @@ public class RegistrationController {
         } catch (UnsupportedEncodingException e) {
             log.error("Error decoding the issuer as URL", e);
         }
-        return "registrationConfirmation";
+        if (!demoMode) {
+            return "registrationConfirmation";
+        } else {
+            return "registrationConfirmationDemo";
+        }
     }
-
 
     /**
      * This generates a JsonNode with all the information that we need to send to the Registration Authorization endpoint in the Platform.
@@ -175,8 +189,7 @@ public class RegistrationController {
      * @param platformRegistrationDTO
      * @return
      */
-    private ToolRegistrationDTO generateToolConfiguration() {
-
+    private ToolRegistrationDTO generateToolConfiguration(PlatformRegistrationDTO platformConfiguration) {
         ToolRegistrationDTO toolRegistrationDTO = new ToolRegistrationDTO();
         toolRegistrationDTO.setApplication_type("web");
         List<String> grantTypes = new ArrayList<>();
@@ -195,40 +208,38 @@ public class RegistrationController {
         //OPTIONAL -->setTos_uri
         //OPTIONAL -->setPolicy_uri
         ToolConfigurationDTO toolConfigurationDTO = new ToolConfigurationDTO();
-        toolConfigurationDTO.setDomain(localUrl.substring(localUrl.indexOf("//") + 2));
+        toolConfigurationDTO.setDomain(domainUrl);
         //OPTIONAL -->setSecondary_domains --> Collections.singletonList
         //OPTIONAL -->setDeployment_id
-        toolConfigurationDTO.setTarget_link_uri(localUrl + TextConstants.LTI3_SUFFIX);
+
+        toolConfigurationDTO.setTarget_link_uri(domainUrl);
+
         //OPTIONAL -->setCustom_parameters --> Map
         toolConfigurationDTO.setDescription(description);
         List<ToolMessagesSupportedDTO> messages = new ArrayList<>();
+
+        // Deep Linking
         ToolMessagesSupportedDTO message1 = new ToolMessagesSupportedDTO();
         message1.setType("LtiDeepLinkingRequest");
         message1.setTarget_link_uri(localUrl + TextConstants.LTI3_SUFFIX);
-        //OPTIONAL: --> message1 --> setLabel
-        //OPTIONAL: --> message1 --> setIcon_uri
-        //OPTIONAL: --> message1 --> setCustom_parameters
+//        OPTIONAL: --> message1 --> setLabel
+//        OPTIONAL: --> message1 --> setIcon_uri
+//        OPTIONAL: --> message1 --> setCustom_parameters
         messages.add(message1);
+
         ToolMessagesSupportedDTO message2 = new ToolMessagesSupportedDTO();
         message2.setType("LtiResourceLinkRequest");
         message2.setTarget_link_uri(localUrl + TextConstants.LTI3_SUFFIX);
         messages.add(message2);
         toolConfigurationDTO.setMessages_supported(messages);
-        //TODO, fill this correctly based on the claims received.
-        List<String> claims = new ArrayList<>();
-        claims.add("iss");
-        claims.add("aud");
-        toolConfigurationDTO.setClaims(claims);
+
+        Set<String> platformAndOptionalClaims = new LinkedHashSet<>(platformConfiguration.getClaims_supported());
+        platformAndOptionalClaims.addAll(LtiStrings.LTI_OPTIONAL_CLAIMS);
+        List<String> toolConfigurationClaims = new ArrayList<>(platformAndOptionalClaims);
+        toolConfigurationDTO.setClaims(toolConfigurationClaims);
+
         toolRegistrationDTO.setToolConfiguration(toolConfigurationDTO);
-        //TODO, fill this correctly based on the scopes received.
-        List<String> scopes = new ArrayList<>();
-        scopes.add("openid");
-        scopes.add("https://purl.imsglobal.org/spec/lti-ags/scope/lineitem");
-        scopes.add("https://purl.imsglobal.org/spec/lti-ags/scope/result.readonly");
-        scopes.add("https://purl.imsglobal.org/spec/lti-ags/scope/score");
-        scopes.add("https://purl.imsglobal.org/spec/lti-reg/scope/registration");
-        scopes.add("https://purl.imsglobal.org/spec/lti-nrps/scope/contextmembership.readonly");
-        toolRegistrationDTO.setScope(scopes);
+        toolRegistrationDTO.setScope(StringUtils.join(platformConfiguration.getScopes_supported(), " "));
 
         return toolRegistrationDTO;
     }

--- a/src/main/java/net/unicon/lti/model/lti/dto/MessagesSupportedDTO.java
+++ b/src/main/java/net/unicon/lti/model/lti/dto/MessagesSupportedDTO.java
@@ -12,8 +12,12 @@
  */
 package net.unicon.lti.model.lti.dto;
 
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import net.unicon.lti.utils.lti.MessagesSupportedDeserializer;
+
 import java.util.List;
 
+@JsonDeserialize(using = MessagesSupportedDeserializer.class)
 public class MessagesSupportedDTO {
     String type;
     List<String> placements;

--- a/src/main/java/net/unicon/lti/model/lti/dto/PlatformRegistrationDTO.java
+++ b/src/main/java/net/unicon/lti/model/lti/dto/PlatformRegistrationDTO.java
@@ -12,11 +12,12 @@
  */
 package net.unicon.lti.model.lti.dto;
 
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
 import java.util.List;
 
-
+@JsonIgnoreProperties(ignoreUnknown = true)
 public class PlatformRegistrationDTO {
 
     private String issuer;

--- a/src/main/java/net/unicon/lti/model/lti/dto/ToolConfigurationDTO.java
+++ b/src/main/java/net/unicon/lti/model/lti/dto/ToolConfigurationDTO.java
@@ -12,6 +12,8 @@
  */
 package net.unicon.lti.model.lti.dto;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
+
 import java.util.List;
 import java.util.Map;
 
@@ -23,7 +25,8 @@ public class ToolConfigurationDTO {
     private String target_link_uri;
     private Map<String, String> custom_parameters;
     private String description;
-    private List<ToolMessagesSupportedDTO> messages_supported;
+    @JsonProperty("messages")
+    private List<ToolMessagesSupportedDTO> messages;
     private List<String> claims;
 
 
@@ -79,11 +82,11 @@ public class ToolConfigurationDTO {
     }
 
     public List<ToolMessagesSupportedDTO> getMessages_supported() {
-        return messages_supported;
+        return messages;
     }
 
-    public void setMessages_supported(List<ToolMessagesSupportedDTO> messages_supported) {
-        this.messages_supported = messages_supported;
+    public void setMessages_supported(List<ToolMessagesSupportedDTO> messages) {
+        this.messages = messages;
     }
 
     public List<String> getClaims() {

--- a/src/main/java/net/unicon/lti/model/lti/dto/ToolRegistrationDTO.java
+++ b/src/main/java/net/unicon/lti/model/lti/dto/ToolRegistrationDTO.java
@@ -34,7 +34,7 @@ public class ToolRegistrationDTO {
     private String policy_uri;
     @JsonProperty("https://purl.imsglobal.org/spec/lti-tool-configuration")
     private ToolConfigurationDTO toolConfiguration;
-    private List<String> scope;
+    private String scope;
 
 
     public ToolRegistrationDTO() {//Empty on purpose
@@ -152,11 +152,11 @@ public class ToolRegistrationDTO {
         this.toolConfiguration = toolConfiguration;
     }
 
-    public List<String> getScope() {
+    public String getScope() {
         return scope;
     }
 
-    public void setScope(List<String> scope) {
+    public void setScope(String scope) {
         this.scope = scope;
     }
 }

--- a/src/main/java/net/unicon/lti/utils/LtiStrings.java
+++ b/src/main/java/net/unicon/lti/utils/LtiStrings.java
@@ -12,6 +12,9 @@
  */
 package net.unicon.lti.utils;
 
+import java.util.Arrays;
+import java.util.List;
+
 public class LtiStrings {
 
     private LtiStrings() {
@@ -172,9 +175,25 @@ public class LtiStrings {
     public static final String JWT = "JWT";
     public static final String RS256 = "RS256";
 
+    public static final List<String> LTI_OPTIONAL_CLAIMS = Arrays.asList(LTI_CONTEXT, LTI_PLATFORM, LTI_LAUNCH_PRESENTATION, LTI_LIS, LTI_ROLE_SCOPE_MENTOR, LTI_CUSTOM);
+
     //Dynamic Registration
     public static final String REGISTRATION_TOKEN = "registration_token";
     public static final String PLATFORM_CONFIGURATION = "platform_configuration";
     public static final String TOOL_CONFIGURATION = "tool_configuration";
+    public static final String RESOURCE_MESSAGE_TYPE = "LtiResourceLinkRequest";
+    public static final String DEEP_LINKING_MESSAGE_TYPE = "LtiDeepLinkingRequest";
+    public static final List<String> MESSAGES_SUPPORTED_TYPES = Arrays.asList(RESOURCE_MESSAGE_TYPE, DEEP_LINKING_MESSAGE_TYPE);
 
+    //Assignments & Grades Service (AGS)
+    public static final String ACTIVITY_PROGRESS_INITIALIZED = "Initialized";
+    public static final String ACTIVITY_PROGRESS_STARTED = "Started";
+    public static final String ACTIVITY_PROGRESS_IN_PROGRESS = "InProgress";
+    public static final String ACTIVITY_PROGRESS_SUBMITTED = "Submitted";
+    public static final String ACTIVITY_PROGRESS_COMPLETED = "Completed";
+    public static final String GRADING_PROGRESS_FULLY_GRADED = "FullyGraded";
+    public static final String GRADING_PROGRESS_PENDING = "Pending";
+    public static final String GRADING_PROGRESS_PENDING_MANUAL = "PendingManual";
+    public static final String GRADING_PROGRESS_FAILED = "Failed";
+    public static final String GRADING_PROGRESS_NOT_READY = "NotReady";
 }

--- a/src/main/java/net/unicon/lti/utils/lti/MessagesSupportedDeserializer.java
+++ b/src/main/java/net/unicon/lti/utils/lti/MessagesSupportedDeserializer.java
@@ -1,0 +1,48 @@
+package net.unicon.lti.utils.lti;
+
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.databind.DeserializationContext;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.deser.std.StdDeserializer;
+import lombok.extern.slf4j.Slf4j;
+import net.unicon.lti.model.lti.dto.MessagesSupportedDTO;
+import net.unicon.lti.utils.LtiStrings;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+
+@Slf4j
+public class MessagesSupportedDeserializer extends StdDeserializer<MessagesSupportedDTO> {
+
+    public MessagesSupportedDeserializer() {
+        this(null);
+    }
+
+    protected MessagesSupportedDeserializer(Class<?> vc) {
+        super(vc);
+    }
+
+    @Override
+    public MessagesSupportedDTO deserialize(JsonParser jp, DeserializationContext ctxt) throws IOException {
+        JsonNode node = jp.getCodec().readTree(jp);
+        MessagesSupportedDTO messagesSupported = new MessagesSupportedDTO();
+        if (node.get("type") != null) {
+            messagesSupported.setType(node.get("type").asText());
+            if (node.get("placements") != null) {
+                List<String> placements = new ArrayList<>();
+                for (JsonNode jsonNode : node.get("placements")) {
+                    placements.add(jsonNode.asText());
+                }
+                messagesSupported.setPlacements(placements);
+            }
+        } else if (LtiStrings.MESSAGES_SUPPORTED_TYPES.contains(node.asText())) {
+            messagesSupported.setType(node.asText());
+        }
+        log.debug("Deserialized Message Type:");
+        log.debug(messagesSupported.getType());
+        log.debug(messagesSupported.getPlacements() != null ? messagesSupported.getPlacements().toString() : null);
+
+        return messagesSupported;
+    }
+}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -11,6 +11,7 @@ server.port=443
 
 #if true, it will display the LTI messages and never jump to the app part. Set to false for prod.
 lti13.demoMode = true
+lti13.enableDynamicRegistration=true
 
 ## thymeleaf base settings
 spring.thymeleaf.mode=HTML5
@@ -59,6 +60,7 @@ oicd.publickey=-----BEGIN PUBLIC KEY-----HERE THE RSA PUBLIC KEY-----END PUBLIC 
 application.url=https://example.unicon.net
 application.name=Unicon LTI 1.3 Demo
 application.description=The Unicon tool to learn about LTI 1.3 in java
+domain.url=https://example.unicon.net
 
 ##if the password is not set, a random one is generated and displayed on start in the log.
 terracotta.admin.user = admin

--- a/src/main/resources/templates/registrationConfirmation.html
+++ b/src/main/resources/templates/registrationConfirmation.html
@@ -14,151 +14,21 @@
 -->
 <!DOCTYPE html>
 <!--suppress CheckEmptyScriptTag -->
-<html xmlns="http://www.w3.org/1999/xhtml" xmlns:th="http://www.thymeleaf.org" xml:lang="en">
-
+<html>
 
 <head>
-    <title>LTI 3 DYNAMIC REGISTRATION CONFIRMATION</title>
-    <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
-    <link rel="stylesheet" type="text/css" th:href="@{/css/bootstrap.min.css}"/>
-    <link rel="stylesheet" type="text/css" th:href="@{/css/style.css}"/>
+    <meta http-equiv="Content-Type" content="application/javascript; charset=UTF-8"/>
 </head>
 
-<script>
-function confirmRegistration() {
-  alert("being called");
-  (window.opener || window.parent).postMessage({subject:'org.imsglobal.lti.close'},'[[${issuer}]]');
-}
-
-</script>
-
 <body>
-<h1>Confirmation after the dynamic registration</h1>
-<p><span th:text="${registration_confirmation}"/></p>
-
-<!--
-<div>
-    <ul class="list-group">
-        <li class="list-group-item list-group-item-primary">
-            <label>client_uri:</label>
-            <span th:text="${tool_confirmation.client_uri}"/>
-        </li>
-        <li class="list-group-item list-group-item-primary">
-            <label>grant_types: </label>
-            <span th:text="${tool_confirmation.grant_types}"/>
-        </li>
-        <li class="list-group-item list-group-item-primary">
-            <label>application_type: </label>
-            <span th:text="${tool_confirmation.application_type}"/>
-        </li>
-        <li class="list-group-item list-group-item-primary">
-            <label>initiate_login_uri: </label>
-            <span th:text="${tool_confirmation.initiate_login_uri}"/>
-        </li>
-        <li class="list-group-item list-group-item-primary">
-            <label>https://purl.imsglobal.org/spec/lti-tool-configuration: </label>
-            <span th:text="${tool_confirmation.jwks_uri}"/>
-        </li>
-        <li class="list-group-item list-group-item-primary">
-            <label>registration_endpoint: </label>
-            <span th:text="${tool_confirmation.registration_endpoint}"/>
-        </li>
-        <li class="list-group-item list-group-item-primary">
-            <label>scopes_supported: </label>
-            <span th:text="${tool_confirmation.scopes_supported}"/>
-        </li>
-        <li class="list-group-item list-group-item-primary">
-            <label>response_types_supported: </label>
-            <span th:text="${tool_confirmation.response_types_supported}"/>
-        </li>
-        <li class="list-group-item list-group-item-primary">
-            <label>subject_types_supported: </label>
-            <span th:text="${tool_confirmation.subject_types_supported}"/>
-        </li>
-        <li class="list-group-item list-group-item-primary">
-            <label>id_token_signing_alg_values_supported: </label>
-            <span th:text="${tool_confirmation.id_token_signing_alg_values_supported}"/>
-        </li>
-        <li class="list-group-item list-group-item-primary">
-            <label>claims_supported: </label>
-            <span th:text="${tool_confirmation.claims_supported}"/>
-        </li>
-        <li class="list-group-item list-group-item-primary">
-            <label>authorization_server: </label>
-            <span th:text="${tool_confirmation.authorization_server}"/>
-        </li>
-        <li class="list-group-item list-group-item-primary">
-            <label>https://purl.imsglobal.org/spec/lti-platform-configuration: </label>
-            <span th:text="${tool_confirmation.platformConfiguration}"/>
-        </li>
-    </ul>
-</div>
--->
-
-
-<!--{
-"client_uri":null,
-"grant_types":[
-"implict",
-"client_credentials"
-],
-"application_type":"web",
-"initiate_login_uri":"https://test-lti.unicon.net/oidc/login_initiations",
-"logo_uri":null,
-"https://purl.imsglobal.org/spec/lti-tool-configuration":{
-"messages_supported":[
-{
-"target_link_uri":"https://test-lti.unicon.net/lti3/",
-"placements":null,
-"label":null,
-"type":"LtiDeepLinkingRequest",
-"custom_parameters":null,
-"icon_uri":null
-},
-{
-"target_link_uri":"https://test-lti.unicon.net/lti3/",
-"placements":null,
-"label":null,
-"type":"LtiResourceLinkRequest",
-"custom_parameters":null,
-"icon_uri":null
-}
-],
-"domain":"test-lti.unicon.net",
-"target_link_uri":"https://test-lti.unicon.net/lti3/",
-"secondary_domains":null,
-"claims":[
-"iss",
-"aud"
-],
-"description":"The Unicon Demo tool",
-"deployment_id":"1",
-"custom_parameters":null
-},
-"redirect_uris":[
-"https://test-lti.unicon.net/lti3/"
-],
-"token_endpoint_auth_method":"private_key_jwt",
-"client_id":"9177d980-6306-45b2-aa69-9d41b417082f",
-"scope":[
-"openid",
-"https://purl.imsglobal.org/spec/lti-ags/scope/lineitem",
-"https://purl.imsglobal.org/spec/lti-ags/scope/result.readonly",
-"https://purl.imsglobal.org/spec/lti-ags/scope/score",
-"https://purl.imsglobal.org/spec/lti-reg/scope/registration",
-"https://purl.imsglobal.org/spec/lti-nrps/scope/contextmembership.readonly"
-],
-"jwks_uri":"https://test-lti.unicon.net/jwks/jwk",
-"tos_uri":null,
-"client_name":"Unicon LTI 1.3",
-"contacts":null,
-"response_types":[
-"id_token"
-],
-"policy_uri":null
-}-->
-
-<button th:onclick="'confirmRegistration();'">Confirm Registration</button>
-
+<script>
+        let done = false;
+        (function() {
+            if (!done) {
+              (window.opener || window.parent).postMessage({subject:'org.imsglobal.lti.close'},'[[${issuer}]]');
+              done = true;
+            }
+        })();
+    </script>
 </body>
 </html>

--- a/src/main/resources/templates/registrationConfirmationDemo.html
+++ b/src/main/resources/templates/registrationConfirmationDemo.html
@@ -1,0 +1,164 @@
+<!--
+
+    Copyright 2021 Unicon (R)
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+<!DOCTYPE html>
+<!--suppress CheckEmptyScriptTag -->
+<html xmlns="http://www.w3.org/1999/xhtml" xmlns:th="http://www.thymeleaf.org" xml:lang="en">
+
+
+<head>
+    <title>LTI 3 DYNAMIC REGISTRATION CONFIRMATION</title>
+    <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
+    <link rel="stylesheet" type="text/css" th:href="@{/css/bootstrap.min.css}"/>
+    <link rel="stylesheet" type="text/css" th:href="@{/css/style.css}"/>
+</head>
+
+<script>
+function confirmRegistration() {
+  alert("being called");
+  (window.opener || window.parent).postMessage({subject:'org.imsglobal.lti.close'},'[[${issuer}]]');
+}
+
+</script>
+
+<body>
+<h1>Confirmation after the dynamic registration</h1>
+<p><span th:text="${registration_confirmation}"/></p>
+
+<!--
+<div>
+    <ul class="list-group">
+        <li class="list-group-item list-group-item-primary">
+            <label>client_uri:</label>
+            <span th:text="${tool_confirmation.client_uri}"/>
+        </li>
+        <li class="list-group-item list-group-item-primary">
+            <label>grant_types: </label>
+            <span th:text="${tool_confirmation.grant_types}"/>
+        </li>
+        <li class="list-group-item list-group-item-primary">
+            <label>application_type: </label>
+            <span th:text="${tool_confirmation.application_type}"/>
+        </li>
+        <li class="list-group-item list-group-item-primary">
+            <label>initiate_login_uri: </label>
+            <span th:text="${tool_confirmation.initiate_login_uri}"/>
+        </li>
+        <li class="list-group-item list-group-item-primary">
+            <label>https://purl.imsglobal.org/spec/lti-tool-configuration: </label>
+            <span th:text="${tool_confirmation.jwks_uri}"/>
+        </li>
+        <li class="list-group-item list-group-item-primary">
+            <label>registration_endpoint: </label>
+            <span th:text="${tool_confirmation.registration_endpoint}"/>
+        </li>
+        <li class="list-group-item list-group-item-primary">
+            <label>scopes_supported: </label>
+            <span th:text="${tool_confirmation.scopes_supported}"/>
+        </li>
+        <li class="list-group-item list-group-item-primary">
+            <label>response_types_supported: </label>
+            <span th:text="${tool_confirmation.response_types_supported}"/>
+        </li>
+        <li class="list-group-item list-group-item-primary">
+            <label>subject_types_supported: </label>
+            <span th:text="${tool_confirmation.subject_types_supported}"/>
+        </li>
+        <li class="list-group-item list-group-item-primary">
+            <label>id_token_signing_alg_values_supported: </label>
+            <span th:text="${tool_confirmation.id_token_signing_alg_values_supported}"/>
+        </li>
+        <li class="list-group-item list-group-item-primary">
+            <label>claims_supported: </label>
+            <span th:text="${tool_confirmation.claims_supported}"/>
+        </li>
+        <li class="list-group-item list-group-item-primary">
+            <label>authorization_server: </label>
+            <span th:text="${tool_confirmation.authorization_server}"/>
+        </li>
+        <li class="list-group-item list-group-item-primary">
+            <label>https://purl.imsglobal.org/spec/lti-platform-configuration: </label>
+            <span th:text="${tool_confirmation.platformConfiguration}"/>
+        </li>
+    </ul>
+</div>
+-->
+
+
+<!--{
+"client_uri":null,
+"grant_types":[
+"implict",
+"client_credentials"
+],
+"application_type":"web",
+"initiate_login_uri":"https://test-lti.unicon.net/oidc/login_initiations",
+"logo_uri":null,
+"https://purl.imsglobal.org/spec/lti-tool-configuration":{
+"messages_supported":[
+{
+"target_link_uri":"https://test-lti.unicon.net/lti3/",
+"placements":null,
+"label":null,
+"type":"LtiDeepLinkingRequest",
+"custom_parameters":null,
+"icon_uri":null
+},
+{
+"target_link_uri":"https://test-lti.unicon.net/lti3/",
+"placements":null,
+"label":null,
+"type":"LtiResourceLinkRequest",
+"custom_parameters":null,
+"icon_uri":null
+}
+],
+"domain":"test-lti.unicon.net",
+"target_link_uri":"https://test-lti.unicon.net/lti3/",
+"secondary_domains":null,
+"claims":[
+"iss",
+"aud"
+],
+"description":"The Unicon Demo tool",
+"deployment_id":"1",
+"custom_parameters":null
+},
+"redirect_uris":[
+"https://test-lti.unicon.net/lti3/"
+],
+"token_endpoint_auth_method":"private_key_jwt",
+"client_id":"9177d980-6306-45b2-aa69-9d41b417082f",
+"scope":[
+"openid",
+"https://purl.imsglobal.org/spec/lti-ags/scope/lineitem",
+"https://purl.imsglobal.org/spec/lti-ags/scope/result.readonly",
+"https://purl.imsglobal.org/spec/lti-ags/scope/score",
+"https://purl.imsglobal.org/spec/lti-reg/scope/registration",
+"https://purl.imsglobal.org/spec/lti-nrps/scope/contextmembership.readonly"
+],
+"jwks_uri":"https://test-lti.unicon.net/jwks/jwk",
+"tos_uri":null,
+"client_name":"Unicon LTI 1.3",
+"contacts":null,
+"response_types":[
+"id_token"
+],
+"policy_uri":null
+}-->
+
+<button th:onclick="'confirmRegistration();'">Confirm Registration</button>
+
+</body>
+</html>

--- a/src/test/java/net/unicon/lti/controller/lti/RegistrationControllerTest.java
+++ b/src/test/java/net/unicon/lti/controller/lti/RegistrationControllerTest.java
@@ -1,0 +1,171 @@
+package net.unicon.lti.controller.lti;
+
+import net.unicon.lti.exceptions.ConnectionException;
+import net.unicon.lti.model.lti.dto.PlatformRegistrationDTO;
+import net.unicon.lti.model.lti.dto.ToolRegistrationDTO;
+import net.unicon.lti.service.lti.RegistrationService;
+import net.unicon.lti.utils.LtiStrings;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.test.util.ReflectionTestUtils;
+import org.springframework.ui.Model;
+import org.springframework.web.client.RestTemplate;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpSession;
+import java.util.Arrays;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.fail;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+public class RegistrationControllerTest {
+
+    private static final String TEST_OPENID_CONFIGURATION_URL = "https://platform.com/get-configuration";
+    private static final String TEST_REGISTRATION_TOKEN = "test-registration-token";
+    private static final String TEST_REGISTRATION_ENDPOINT = "https://platform.com/register-tool";
+    private static final String TEST_PLATFORM_ISSUER = "https://platform.com";
+    private static final List TEST_SCOPES = Arrays.asList("example-scope1", "example-scope2");
+
+    @InjectMocks
+    private RegistrationController registrationController = new RegistrationController();
+
+    @Mock
+    private RegistrationService registrationService;
+
+    @Mock
+    private RestTemplate restTemplate;
+
+    @Mock
+    private HttpServletRequest req;
+
+    @Mock
+    private HttpSession session;
+
+    @Mock
+    private Model model;
+
+    @BeforeEach
+    public void setUp() {
+        MockitoAnnotations.openMocks(this);
+        when(req.getSession()).thenReturn(session);
+    }
+
+    @Test
+    public void testRegistration() {
+        PlatformRegistrationDTO platformRegistration = new PlatformRegistrationDTO();
+        platformRegistration.setClaims_supported(LtiStrings.LTI_OPTIONAL_CLAIMS);
+        platformRegistration.setScopes_supported(TEST_SCOPES);
+        platformRegistration.setRegistration_endpoint(TEST_REGISTRATION_ENDPOINT);
+        platformRegistration.setIssuer(TEST_PLATFORM_ISSUER);
+        ResponseEntity<PlatformRegistrationDTO> responseEntity = new ResponseEntity<>(platformRegistration, HttpStatus.OK);
+        when(restTemplate.exchange(eq(TEST_OPENID_CONFIGURATION_URL), eq(HttpMethod.GET), any(HttpEntity.class), eq(PlatformRegistrationDTO.class))).thenReturn(responseEntity);
+
+        try {
+            when(registrationService.callDynamicRegistration(eq(TEST_REGISTRATION_TOKEN), any(ToolRegistrationDTO.class), eq(TEST_REGISTRATION_ENDPOINT))).thenReturn("test-success");
+
+            String registrationOutput = registrationController.registration(TEST_OPENID_CONFIGURATION_URL, TEST_REGISTRATION_TOKEN, req, model);
+
+            verify(restTemplate).exchange(eq(TEST_OPENID_CONFIGURATION_URL), eq(HttpMethod.GET), any(HttpEntity.class), eq(PlatformRegistrationDTO.class));
+            verify(registrationService).callDynamicRegistration(eq(TEST_REGISTRATION_TOKEN), any(ToolRegistrationDTO.class), eq(TEST_REGISTRATION_ENDPOINT));
+            verify(session).setAttribute(eq(LtiStrings.REGISTRATION_TOKEN), eq(TEST_REGISTRATION_TOKEN));
+            verify(session).setAttribute(eq(LtiStrings.PLATFORM_CONFIGURATION), eq(platformRegistration));
+            verify(session).setAttribute(eq(LtiStrings.TOOL_CONFIGURATION), any(ToolRegistrationDTO.class));
+            assertEquals("registrationConfirmation", registrationOutput);
+        } catch (ConnectionException e) {
+            fail();
+        }
+    }
+
+    @Test
+    public void testRegistrationDemo() {
+        ReflectionTestUtils.setField(registrationController, "demoMode", true);
+        PlatformRegistrationDTO platformRegistration = new PlatformRegistrationDTO();
+        platformRegistration.setClaims_supported(LtiStrings.LTI_OPTIONAL_CLAIMS);
+        platformRegistration.setScopes_supported(TEST_SCOPES);
+        ResponseEntity<PlatformRegistrationDTO> responseEntity = new ResponseEntity<>(platformRegistration, HttpStatus.OK);
+        when(restTemplate.exchange(eq(TEST_OPENID_CONFIGURATION_URL), eq(HttpMethod.GET), any(HttpEntity.class), eq(PlatformRegistrationDTO.class))).thenReturn(responseEntity);
+        try {
+            String registrationOutput = registrationController.registration(TEST_OPENID_CONFIGURATION_URL, TEST_REGISTRATION_TOKEN, req, model);
+
+            verify(restTemplate).exchange(eq(TEST_OPENID_CONFIGURATION_URL), eq(HttpMethod.GET), any(HttpEntity.class), eq(PlatformRegistrationDTO.class));
+            verify(registrationService, never()).callDynamicRegistration(eq(TEST_REGISTRATION_TOKEN), any(ToolRegistrationDTO.class), eq(TEST_REGISTRATION_ENDPOINT));
+            verify(session).setAttribute(eq(LtiStrings.REGISTRATION_TOKEN), eq(TEST_REGISTRATION_TOKEN));
+            verify(session).setAttribute(eq(LtiStrings.PLATFORM_CONFIGURATION), eq(platformRegistration));
+            verify(session).setAttribute(eq(LtiStrings.TOOL_CONFIGURATION), any(ToolRegistrationDTO.class));
+            assertEquals("registrationRedirect", registrationOutput);
+        } catch (ConnectionException e) {
+            fail();
+        }
+    }
+
+    @Test
+    public void testRegistrationNoPlatformConfiguration() {
+        ResponseEntity<PlatformRegistrationDTO> responseEntity = new ResponseEntity<>(null, HttpStatus.OK);
+        when(restTemplate.exchange(eq(TEST_OPENID_CONFIGURATION_URL), eq(HttpMethod.GET), any(HttpEntity.class), eq(PlatformRegistrationDTO.class))).thenReturn(responseEntity);
+
+        try {
+            String registrationOutput = registrationController.registration(TEST_OPENID_CONFIGURATION_URL, TEST_REGISTRATION_TOKEN, req, model);
+
+            verify(restTemplate).exchange(eq(TEST_OPENID_CONFIGURATION_URL), eq(HttpMethod.GET), any(HttpEntity.class), eq(PlatformRegistrationDTO.class));
+            verify(registrationService, never()).callDynamicRegistration(eq(TEST_REGISTRATION_TOKEN), any(ToolRegistrationDTO.class), eq(TEST_REGISTRATION_ENDPOINT));
+            verify(session).setAttribute(eq(LtiStrings.REGISTRATION_TOKEN), eq(TEST_REGISTRATION_TOKEN));
+            verify(session, never()).setAttribute(eq(LtiStrings.PLATFORM_CONFIGURATION), any(PlatformRegistrationDTO.class));
+            verify(session, never()).setAttribute(eq(LtiStrings.TOOL_CONFIGURATION), any(ToolRegistrationDTO.class));
+            assertEquals("registrationError", registrationOutput);
+        } catch (ConnectionException e) {
+            fail();
+        }
+    }
+
+    @Test
+    public void testRegistrationNoResponseFromPlatformConfiguration() {
+        when(restTemplate.exchange(eq(TEST_OPENID_CONFIGURATION_URL), eq(HttpMethod.GET), any(HttpEntity.class), eq(PlatformRegistrationDTO.class))).thenReturn(null);
+
+        try {
+            String registrationOutput = registrationController.registration(TEST_OPENID_CONFIGURATION_URL, TEST_REGISTRATION_TOKEN, req, model);
+
+            verify(restTemplate).exchange(eq(TEST_OPENID_CONFIGURATION_URL), eq(HttpMethod.GET), any(HttpEntity.class), eq(PlatformRegistrationDTO.class));
+            verify(registrationService, never()).callDynamicRegistration(eq(TEST_REGISTRATION_TOKEN), any(ToolRegistrationDTO.class), eq(TEST_REGISTRATION_ENDPOINT));
+            verify(session).setAttribute(eq(LtiStrings.REGISTRATION_TOKEN), eq(TEST_REGISTRATION_TOKEN));
+            verify(session, never()).setAttribute(eq(LtiStrings.PLATFORM_CONFIGURATION), any(PlatformRegistrationDTO.class));
+            verify(session, never()).setAttribute(eq(LtiStrings.TOOL_CONFIGURATION), any(ToolRegistrationDTO.class));
+            assertEquals("registrationError", registrationOutput);
+        } catch (ConnectionException e) {
+            fail();
+        }
+    }
+
+    @Test
+    public void testRegistrationNot2xxStatusForPlatformConfiguration() {
+        PlatformRegistrationDTO platformRegistration = new PlatformRegistrationDTO();
+        ResponseEntity<PlatformRegistrationDTO> responseEntity = new ResponseEntity<>(platformRegistration, HttpStatus.NOT_FOUND);
+        when(restTemplate.exchange(eq(TEST_OPENID_CONFIGURATION_URL), eq(HttpMethod.GET), any(HttpEntity.class), eq(PlatformRegistrationDTO.class))).thenReturn(responseEntity);
+
+        try {
+            String registrationOutput = registrationController.registration(TEST_OPENID_CONFIGURATION_URL, TEST_REGISTRATION_TOKEN, req, model);
+
+            verify(restTemplate).exchange(eq(TEST_OPENID_CONFIGURATION_URL), eq(HttpMethod.GET), any(HttpEntity.class), eq(PlatformRegistrationDTO.class));
+            verify(registrationService, never()).callDynamicRegistration(eq(TEST_REGISTRATION_TOKEN), any(ToolRegistrationDTO.class), eq(TEST_REGISTRATION_ENDPOINT));
+            verify(session).setAttribute(eq(LtiStrings.REGISTRATION_TOKEN), eq(TEST_REGISTRATION_TOKEN));
+            verify(session, never()).setAttribute(eq(LtiStrings.PLATFORM_CONFIGURATION), any(PlatformRegistrationDTO.class));
+            verify(session, never()).setAttribute(eq(LtiStrings.TOOL_CONFIGURATION), any(ToolRegistrationDTO.class));
+            assertEquals("registrationError", registrationOutput);
+        } catch (ConnectionException e) {
+            fail();
+        }
+
+    }
+}

--- a/src/test/java/net/unicon/lti/service/lti/RegistrationServiceTest.java
+++ b/src/test/java/net/unicon/lti/service/lti/RegistrationServiceTest.java
@@ -1,0 +1,109 @@
+package net.unicon.lti.service.lti.test;
+
+import net.unicon.lti.exceptions.ConnectionException;
+import net.unicon.lti.exceptions.helper.ExceptionMessageGenerator;
+import net.unicon.lti.model.lti.dto.ToolRegistrationDTO;
+import net.unicon.lti.service.lti.RegistrationService;
+import net.unicon.lti.service.lti.impl.RegistrationServiceImpl;
+import org.apache.commons.lang3.StringUtils;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.client.RestTemplate;
+import org.springframework.web.util.UriTemplateHandler;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.fail;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.argThat;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+public class RegistrationServiceTest {
+
+    private static final String TEST_REGISTRATION_ENDPOINT = "https://platform.com/register-tool";
+
+    @InjectMocks
+    private RegistrationService registrationService = new RegistrationServiceImpl();
+
+    @Mock
+    private ExceptionMessageGenerator exceptionMessageGenerator;
+
+    @Mock
+    private RestTemplate restTemplate;
+
+    @BeforeEach
+    public void setUp() {
+        MockitoAnnotations.openMocks(this);
+    }
+
+    @Test
+    public void testCallDynamicRegistration() {
+        ToolRegistrationDTO toolRegistration = new ToolRegistrationDTO();
+        when(restTemplate.exchange(eq(TEST_REGISTRATION_ENDPOINT), eq(HttpMethod.POST), any(HttpEntity.class), eq(String.class))).thenReturn(new ResponseEntity<>("test-success", HttpStatus.OK));
+
+        try {
+            String answer = registrationService.callDynamicRegistration(null, toolRegistration, TEST_REGISTRATION_ENDPOINT);
+
+            verify(restTemplate).exchange(eq(TEST_REGISTRATION_ENDPOINT), eq(HttpMethod.POST),
+                    argThat((HttpEntity entity) ->
+                            entity.getHeaders().get(HttpHeaders.AUTHORIZATION) == null && entity.getBody() == toolRegistration
+                    ),
+                    eq(String.class));
+            verify(exceptionMessageGenerator, never()).exceptionMessage(any(String.class), any(Exception.class));
+            assertEquals(answer, "test-success");
+        } catch (ConnectionException e) {
+            fail();
+        }
+    }
+
+    @Test
+    public void testCallDynamicRegistrationWithToken() {
+        String mockToken = "mock-token";
+        ToolRegistrationDTO toolRegistration = new ToolRegistrationDTO();
+        when(restTemplate.exchange(eq(TEST_REGISTRATION_ENDPOINT), eq(HttpMethod.POST), any(HttpEntity.class), eq(String.class))).thenReturn(new ResponseEntity<>("test-success", HttpStatus.OK));
+
+        try {
+            String answer = registrationService.callDynamicRegistration(mockToken, toolRegistration, TEST_REGISTRATION_ENDPOINT);
+
+            verify(restTemplate).setUriTemplateHandler(any(UriTemplateHandler.class));
+            verify(restTemplate).exchange(eq(TEST_REGISTRATION_ENDPOINT), eq(HttpMethod.POST),
+                    argThat((HttpEntity entity) ->
+                            StringUtils.equals(entity.getHeaders().get(HttpHeaders.AUTHORIZATION).get(0), "Bearer " + mockToken) && entity.getBody() == toolRegistration
+                    ),
+                    eq(String.class));
+            verify(exceptionMessageGenerator, never()).exceptionMessage(any(String.class), any(Exception.class));
+            assertEquals(answer, "test-success");
+        } catch (ConnectionException e) {
+            fail();
+        }
+    }
+
+    @Test
+    public void testCallDynamicRegistrationNot2xxSuccessful() throws ConnectionException {
+        ToolRegistrationDTO toolRegistration = new ToolRegistrationDTO();
+        when(restTemplate.exchange(eq(TEST_REGISTRATION_ENDPOINT), eq(HttpMethod.POST), any(HttpEntity.class), eq(String.class))).thenReturn(new ResponseEntity<>("test-failure", HttpStatus.INTERNAL_SERVER_ERROR));
+
+        assertThrows(ConnectionException.class, () -> {
+            registrationService.callDynamicRegistration(null, toolRegistration, TEST_REGISTRATION_ENDPOINT);
+        });
+
+        verify(restTemplate).exchange(eq(TEST_REGISTRATION_ENDPOINT), eq(HttpMethod.POST),
+                argThat((HttpEntity entity) ->
+                        entity.getHeaders().get(HttpHeaders.AUTHORIZATION) == null && entity.getBody() == toolRegistration
+                ),
+                eq(String.class));
+        verify(exceptionMessageGenerator).exceptionMessage(any(String.class), any(Exception.class));
+    }
+
+}


### PR DESCRIPTION
This update makes Dynamic Registration functional for D2L/Brightspace and Moodle in demo mode and non-demo mode. It does not automatically post the configuration to the tool after the registration is complete, however. That functionality may be implemented in the future.

# Steps to Test
## For D2L/Brightspace:

1. Ensure that you have created a course in Brightspace. Ensure that the `lti13.demoMode` is set to `true` in the `application.properties` file before starting the tool.
2. Go to Brightspace: https://devcop.brightspace.com
3. Ensure that you log in as a user that is at least at the SubAdministrator level.
4. Click on the gear icon in the upper right.
5. Under Organization Related, find the link that says Manage Extensibility and click on it. If you don't see the Manage Extensibility link, then your user doesn't have the correct permissions to add LTI tools (you're logged in as the wrong user).
6. Click on the LTI Advantage tab.
7. Click on the Register Tool button.
8. Ensure your app has an ssl certificate and that it has a non-localhost domain (e.g. is running with ngrok: ngrok http 443).
9. Select the radio button for "Dynamic"
10. Enter the /registration endpoint of the middleware (e.g. https://9e9a-184-101-8-242.ngrok.io/registration).
11. Check the box for "Configure Deployment"
12. Click the Register button.
13. Click on the newly registered tool
14. Toggle the switch to enable the tool
15. Scroll to the bottom and click View Deployments (this will open a new tab)
16. Click on the tool deployment
17. Scroll to the bottom and click "Add Org Units"
18. Select the course or courses or org units that you would like to have access to the tool, and click "Add"
19. Take note of the Deployment Id
20. Click "Save and Close"
21. Close the tab for the Deployments page.
22. Take note of all of the Brightspace Registration Details.
23. Click "Save and Close".
24. Use the middleware's /config endpoint to POST all of the registration information that was noted.
25. Go to your Brightspace course
26. Click on Content. If you don't have a Module, add one.
27. Click on Existing Activities > External Learning Tools > your tool
28. Click on the LTI link that was added for the tool.
29. Note that the standard launch for the demo tool functions.

## For Moodle:

1. In a Moodle environment, set up a course.
2. In Moodle, click on Site administration > Plugins > (scroll in Activity modules section) Manage tools
3. Enter the /registration endpoint of the middleware (e.g. https://9e9a-184-101-8-242.ngrok.io/registration).
4. Click Add LTI Advantage
5. Wait a moment for the process to complete.
6. Click the Activate button for the newly registered tool.
7. Click on the lines icon of the tool to View configuration details.
8. Use the middleware's /config endpoint to POST all of the registration information that was noted.
9. Exit out of the configuration details popup and go to your course in Moodle.
10. Create an LTI link from your newly registered tool.
11. Note that the LTI 1.3 process takes place just as in Canvas.
