### PR TITLE
Fix infinite recursion in config endpoint

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,3 +34,5 @@ application-local.properties
 *.pem
 *.crt
 *.p12
+
+*.DS_Store

--- a/src/main/java/net/unicon/lti/controller/lti/ConfigurationController.java
+++ b/src/main/java/net/unicon/lti/controller/lti/ConfigurationController.java
@@ -18,6 +18,8 @@ import net.unicon.lti.repository.PlatformDeploymentRepository;
 import net.unicon.lti.utils.TextConstants;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Scope;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Controller;
@@ -27,6 +29,7 @@ import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.ResponseBody;
 
 import java.util.List;
@@ -46,9 +49,9 @@ public class ConfigurationController {
 
     @GetMapping(value = "/", produces = "application/json;")
     @ResponseBody
-    public ResponseEntity<List<PlatformDeployment>> displayConfigs() {
+    public ResponseEntity<Page<PlatformDeployment>> displayConfigs(@RequestParam(defaultValue = "0") Integer page, @RequestParam(defaultValue = "10") Integer size) {
 
-        List<PlatformDeployment> platformDeploymentListEntityList = platformDeploymentRepository.findAll();
+        Page<PlatformDeployment> platformDeploymentListEntityList = platformDeploymentRepository.findAll(PageRequest.of(page, size));
         if (platformDeploymentListEntityList.isEmpty()) {
             return new ResponseEntity<>(HttpStatus.NO_CONTENT);
             // You many decide to return HttpStatus.NOT_FOUND

--- a/src/main/java/net/unicon/lti/model/PlatformDeployment.java
+++ b/src/main/java/net/unicon/lti/model/PlatformDeployment.java
@@ -12,6 +12,9 @@
  */
 package net.unicon.lti.model;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
 import javax.persistence.Basic;
 import javax.persistence.Column;
 import javax.persistence.Entity;
@@ -53,6 +56,7 @@ public class PlatformDeployment extends BaseEntity {
     @Column(name = "deployment_id")
     private String deploymentId;  // Where in the platform we need to ask for the oidc authentication.
 
+    @JsonProperty(access = JsonProperty.Access.WRITE_ONLY)
     @OneToMany(mappedBy = "platformDeployment", fetch = FetchType.LAZY)
     private Set<LtiContextEntity> contexts;
 
@@ -121,6 +125,7 @@ public class PlatformDeployment extends BaseEntity {
         this.deploymentId = deploymentId;
     }
 
+    @JsonIgnore
     public Set<LtiContextEntity> getContexts() {
         return contexts;
     }

--- a/src/test/java/net/unicon/lti/controller/lti/ConfigurationControllerTest.java
+++ b/src/test/java/net/unicon/lti/controller/lti/ConfigurationControllerTest.java
@@ -10,22 +10,24 @@ import org.mockito.MockitoAnnotations;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.when;
 
 @WebMvcTest(ConfigurationController.class)
 public class ConfigurationControllerTest {
     private PlatformDeployment platformDeployment = new PlatformDeployment();
-    private ResponseEntity<PlatformDeployment> platformDeploymentResponseEntity;
 
     @InjectMocks
     private ConfigurationController configurationController = new ConfigurationController();
@@ -44,21 +46,24 @@ public class ConfigurationControllerTest {
 
     @Test
     public void testDisplayConfigs() {
-        ResponseEntity<List<PlatformDeployment>> platformDeploymentResponseEntity = new ResponseEntity<>(Arrays.asList(platformDeployment), HttpStatus.OK);
-        when(platformDeploymentRepository.findAll()).thenReturn(Arrays.asList(platformDeployment));
+        Page<PlatformDeployment> platformDeploymentPage = new PageImpl<>(Arrays.asList(platformDeployment));
+        ResponseEntity<Page<PlatformDeployment>> platformDeploymentResponseEntity = new ResponseEntity<>(platformDeploymentPage, HttpStatus.OK);
+        when(platformDeploymentRepository.findAll(any(PageRequest.class))).thenReturn(platformDeploymentPage);
 
-        ResponseEntity<List<PlatformDeployment>> found = configurationController.displayConfigs();
-        Mockito.verify(platformDeploymentRepository).findAll();
+        ResponseEntity<Page<PlatformDeployment>> found = configurationController.displayConfigs(0, 10);
+        Mockito.verify(platformDeploymentRepository).findAll(any(PageRequest.class));
         assertEquals(platformDeploymentResponseEntity.getStatusCode(), found.getStatusCode());
         assertEquals(platformDeploymentResponseEntity.getBody(), found.getBody());
     }
 
     @Test
     public void testDisplayConfigsNotFound() {
-        when(platformDeploymentRepository.findAll()).thenReturn(new ArrayList<>());
+        Page<PlatformDeployment> platformDeploymentPage = new PageImpl<>(new ArrayList<>());
+        ResponseEntity<Page<PlatformDeployment>> platformDeploymentResponseEntity = new ResponseEntity<>(platformDeploymentPage, HttpStatus.OK);
+        when(platformDeploymentRepository.findAll(any(PageRequest.class))).thenReturn(platformDeploymentPage);
 
-        ResponseEntity<List<PlatformDeployment>> found = configurationController.displayConfigs();
-        Mockito.verify(platformDeploymentRepository).findAll();
+        ResponseEntity<Page<PlatformDeployment>> found = configurationController.displayConfigs(0, 10);
+        Mockito.verify(platformDeploymentRepository).findAll(any(PageRequest.class));
         assertEquals(HttpStatus.NO_CONTENT, found.getStatusCode());
         assertNull(found.getBody());
     }


### PR DESCRIPTION
 - The bidirectional relationship between PlatformDeployment and LtiContext led to an infinite recursion in the JSON output from the GET config endpoint, making the output difficult to read, making it take longer, and preventing the entire set of PlatformDeployment configurations from being retrievable via this endpoint. Removing the context field from this JSON output has resolved those three issues.
 - Pagination was added to the GET config endpoint so that when the configuration database table grows to be large, its entirety is not fetched at once when the GET config endpoint is called, leading to slow requests. Pagination can be used by adding `?page=1` to the end of the request.