### PR TITLE
Fix issue where multiple deployments was not allowed

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -64,6 +64,13 @@
             <scope>test</scope>
         </dependency>
         <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-inline</artifactId>
+            <version>3.11.0</version>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
             <groupId>com.h2database</groupId>
             <artifactId>h2</artifactId>
             <scope>test</scope>

--- a/src/main/java/net/unicon/lti/controller/lti/LTI3Controller.java
+++ b/src/main/java/net/unicon/lti/controller/lti/LTI3Controller.java
@@ -68,7 +68,7 @@ public class LTI3Controller {
     LtiContextRepository ltiContextRepository;
 
     @RequestMapping({"", "/"})
-    public String home(HttpServletRequest req, Principal principal, Model model) throws DataServiceException, ConnectionException {
+    public String lti3(HttpServletRequest req, Model model) throws DataServiceException, ConnectionException {
 
         //First we will get the state, validate it
         String state = req.getParameter("state");
@@ -78,15 +78,17 @@ public class LTI3Controller {
             Jws<Claims> claims = ltijwtService.validateState(state);
             LTI3Request lti3Request = LTI3Request.getInstance(link);
             // This is just an extra check that we have added, but it is not necessary.
-            // Checking that the clientId in the status matches the one coming with the ltiRequest.
-            if (!claims.getBody().get("clientId").equals(lti3Request.getAud())) {
-                model.addAttribute(TextConstants.ERROR, " Bad Client Id");
+            // Checking that the clientId in the state (if sent in OIDC initiation request) matches the one coming with the ltiRequest.
+            String clientIdFromState = claims.getBody().get("clientId") != null ? claims.getBody().get("clientId").toString() : null;
+            if (clientIdFromState != null && !clientIdFromState.equals(lti3Request.getAud())) {
+                model.addAttribute(TextConstants.ERROR, "Invalid Client Id");
                 return TextConstants.LTI3ERROR;
             }
             // This is just an extra check that we have added, but it is not necessary.
-            // Checking that the deploymentId in the status matches the one coming with the ltiRequest.
-            if (!claims.getBody().get("ltiDeploymentId").equals(lti3Request.getLtiDeploymentId())) {
-                model.addAttribute(TextConstants.ERROR, " Bad Deployment Id");
+            // Checking that the deploymentId in the state (if sent in the OIDC initiation request) matches the one coming with the ltiRequest.
+            String deploymentIdFromState = claims.getBody().get("ltiDeploymentId") != null ? claims.getBody().get("ltiDeploymentId").toString() : null;
+            if (deploymentIdFromState != null && !deploymentIdFromState.equals(lti3Request.getLtiDeploymentId())) {
+                model.addAttribute(TextConstants.ERROR, "Invalid Deployment Id");
                 return TextConstants.LTI3ERROR;
             }
             //We add the request to the model so it can be displayed. But, in a real application, we would start

--- a/src/main/java/net/unicon/lti/model/lti/dto/LoginInitiationDTO.java
+++ b/src/main/java/net/unicon/lti/model/lti/dto/LoginInitiationDTO.java
@@ -14,6 +14,13 @@ package net.unicon.lti.model.lti.dto;
 
 import javax.servlet.http.HttpServletRequest;
 
+import static net.unicon.lti.utils.LtiStrings.OIDC_CLIENT_ID;
+import static net.unicon.lti.utils.LtiStrings.OIDC_DEPLOYMENT_ID;
+import static net.unicon.lti.utils.LtiStrings.OIDC_ISS;
+import static net.unicon.lti.utils.LtiStrings.OIDC_LOGIN_HINT;
+import static net.unicon.lti.utils.LtiStrings.OIDC_LTI_MESSAGE_HINT;
+import static net.unicon.lti.utils.LtiStrings.OIDC_TARGET_LINK_URI;
+
 public class LoginInitiationDTO {
 
     private String iss;
@@ -37,12 +44,12 @@ public class LoginInitiationDTO {
     }
 
     public LoginInitiationDTO(HttpServletRequest req) {
-        this(req.getParameter("iss"),
-                req.getParameter("login_hint"),
-                req.getParameter("target_link_uri"),
-                req.getParameter("lti_message_hint"),
-                req.getParameter("client_id"),
-                req.getParameter("lti_deployment_id")
+        this(req.getParameter(OIDC_ISS),
+                req.getParameter(OIDC_LOGIN_HINT),
+                req.getParameter(OIDC_TARGET_LINK_URI),
+                req.getParameter(OIDC_LTI_MESSAGE_HINT),
+                req.getParameter(OIDC_CLIENT_ID),
+                req.getParameter(OIDC_DEPLOYMENT_ID)
         );
     }
 

--- a/src/main/java/net/unicon/lti/security/lti/LTI3OAuthProviderProcessingFilter.java
+++ b/src/main/java/net/unicon/lti/security/lti/LTI3OAuthProviderProcessingFilter.java
@@ -113,7 +113,7 @@ public class LTI3OAuthProviderProcessingFilter extends GenericFilterBean {
                 if (jws != null) {
                     //Here we create and populate the LTI3Request object and we will add it to the httpServletRequest, so the redirect endpoint will have all that information
                     //ready and will be able to use it.
-                    LTI3Request lti3Request = new LTI3Request(httpServletRequest, ltiDataService, true, link); // IllegalStateException if invalid
+                    LTI3Request lti3Request = new LTI3Request(httpServletRequest, ltiDataService, true, link, null); // IllegalStateException if invalid
                     httpServletRequest.setAttribute("LTI3", true); // indicate this request is an LTI3 one
                     httpServletRequest.setAttribute("lti3_valid", lti3Request.isLoaded() && lti3Request.isComplete()); // is LTI3 request totally valid and complete
                     httpServletRequest.setAttribute("lti3_message_type", lti3Request.getLtiMessageType()); // is LTI3 request totally valid and complete

--- a/src/main/java/net/unicon/lti/utils/LtiStrings.java
+++ b/src/main/java/net/unicon/lti/utils/LtiStrings.java
@@ -24,6 +24,18 @@ public class LtiStrings {
     public static final int ROLE_STUDENT = 0;
     public static final int ROLE_INSTRUCTOR = 1;
 
+    // OIDC Initiation Parameters
+    public static final String OIDC_NONE = "none";
+    public static final String OIDC_FORM_POST = "form_post";
+    public static final String OIDC_ID_TOKEN = "id_token";
+    public static final String OIDC_OPEN_ID = "openid";
+    public static final String OIDC_ISS = "iss";
+    public static final String OIDC_LOGIN_HINT = "login_hint";
+    public static final String OIDC_LTI_MESSAGE_HINT = "lti_message_hint";
+    public static final String OIDC_TARGET_LINK_URI = "target_link_uri";
+    public static final String OIDC_CLIENT_ID = "client_id";
+    public static final String OIDC_DEPLOYMENT_ID = "lti_deployment_id";
+
     //Those are used by the session.
     public static final String LTI_SESSION_USER_ID = "user_id";
     public static final String LTI_SESSION_USER_ROLE = "user_role";

--- a/src/main/java/net/unicon/lti/utils/lti/LtiOidcUtils.java
+++ b/src/main/java/net/unicon/lti/utils/lti/LtiOidcUtils.java
@@ -26,6 +26,8 @@ import org.slf4j.LoggerFactory;
 import java.io.IOException;
 import java.security.GeneralSecurityException;
 import java.security.Key;
+import java.time.LocalDateTime;
+import java.time.ZoneId;
 import java.util.Date;
 import java.util.Map;
 
@@ -41,16 +43,15 @@ public class LtiOidcUtils {
      * The state will be returned when the tool makes the final call to us, so it is useful to send information
      * to our own tool, to know about the request.
      */
-    public static String generateState(LTIDataService ltiDataService, PlatformDeployment platformDeployment, Map<String, String> authRequestMap, LoginInitiationDTO loginInitiationDTO, String clientIdValue, String deploymentIdValue) throws GeneralSecurityException, IOException {
-
+    public static String generateState(LTIDataService ltiDataService, Map<String, String> authRequestMap, LoginInitiationDTO loginInitiationDTO, String clientIdValue, String deploymentIdValue) throws GeneralSecurityException {
         Date date = new Date();
         Key issPrivateKey = OAuthUtils.loadPrivateKey(ltiDataService.getOwnPrivateKey());
         String state = Jwts.builder()
                 .setHeaderParam("kid", TextConstants.DEFAULT_KID)  // The key id used to sign this
                 .setHeaderParam("typ", "JWT") // The type
                 .setIssuer("ltiStarter")  //This is our own identifier, to know that we are the issuer.
-                .setSubject(platformDeployment.getIss()) // We store here the platform issuer to check that matches with the issuer received later
-                .setAudience(platformDeployment.getClientId())  //We send here the clientId to check it later.
+                .setSubject(loginInitiationDTO.getIss()) // We store here the platform issuer to check that matches with the issuer received later
+                .setAudience(clientIdValue)  //We send here the clientId to check it later.
                 .setExpiration(DateUtils.addSeconds(date, 3600)) //a java.util.Date
                 .setNotBefore(date) //a java.util.Date
                 .setIssuedAt(date) // for example, now

--- a/src/test/java/net/unicon/lti/controller/lti/LTI3ControllerTest.java
+++ b/src/test/java/net/unicon/lti/controller/lti/LTI3ControllerTest.java
@@ -1,0 +1,230 @@
+package net.unicon.lti.controller.lti;
+
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.Jws;
+import io.jsonwebtoken.Jwts;
+import net.unicon.lti.exceptions.ConnectionException;
+import net.unicon.lti.exceptions.DataServiceException;
+import net.unicon.lti.model.LtiContextEntity;
+import net.unicon.lti.repository.LtiContextRepository;
+import net.unicon.lti.repository.LtiLinkRepository;
+import net.unicon.lti.service.app.APIJWTService;
+import net.unicon.lti.service.lti.LTIDataService;
+import net.unicon.lti.service.lti.LTIJWTService;
+import net.unicon.lti.utils.LtiStrings;
+import net.unicon.lti.utils.TextConstants;
+import net.unicon.lti.utils.lti.LTI3Request;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.MockedStatic;
+import org.mockito.Mockito;
+import org.mockito.MockitoAnnotations;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.http.HttpStatus;
+import org.springframework.ui.ExtendedModelMap;
+import org.springframework.ui.Model;
+import org.springframework.web.server.ResponseStatusException;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import java.security.GeneralSecurityException;
+import java.security.KeyPair;
+import java.security.KeyPairGenerator;
+import java.security.NoSuchAlgorithmException;
+import java.util.Base64;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.when;
+
+@WebMvcTest(LTI3Controller.class)
+public class LTI3ControllerTest {
+    private static String VALID_STATE = "eyJraWQiOiJPV05LRVkiLCJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiJ9.eyJpc3MiOiJsdGlTdGFydGVyIiwic3ViIjoiaHR0cHM6Ly9jYW52YXMuaW5zdHJ1Y3R1cmUuY29tIiwiYXVkIjoiOTcxNDAwMDAwMDAwMDAyMzAiLCJleHAiOjE2MzM1NDE3MTAsIm5iZiI6MTYzMzUzODExMCwiaWF0IjoxNjMzNTM4MTEwLCJqdGkiOiJkYmIzNWI5Ny02MTEzLTQ3YmUtYWYxOC1jYTg3MTM5NTkzMWEiLCJvcmlnaW5hbF9pc3MiOiJodHRwczovL2NhbnZhcy5pbnN0cnVjdHVyZS5jb20iLCJsb2dpbkhpbnQiOiI0MDdhNDE4MjUwN2YwZjM3YTU0ZWM1NWQ1MDE5MzljMWQzZDEwMmU2IiwibHRpTWVzc2FnZUhpbnQiOiJleUowZVhBaU9pSktWMVFpTENKaGJHY2lPaUpJVXpJMU5pSjkuZXlKMlpYSnBabWxsY2lJNkltRXdOek16WldZelpXUXlNbUl5WlRCa1ltSXlZakpoTlRZME5qWm1OakpoTXpFMlptWXlNMlptTkdKa09XSTVZVFpqWmpaaVlqUTVZbVkwTXpsa05UUmlZalJtWXpaalpETmpPRFE1TldGbVpEZzJNbVZoTXpkbE1UZzRORGcyTnpJNFlqUXhPVGcwWm1WbFpqVXhPVEF5TnpGbFptTmxOR0V4T0RVM05UZ3dJaXdpWTJGdWRtRnpYMlJ2YldGcGJpSTZJblZ1YVdOdmJpNXBibk4wY25WamRIVnlaUzVqYjIwaUxDSmpiMjUwWlhoMFgzUjVjR1VpT2lKRGIzVnljMlVpTENKamIyNTBaWGgwWDJsa0lqbzVOekUwTURBd01EQXdNREF3TXpNME9Dd2lZMkZ1ZG1GelgyeHZZMkZzWlNJNkltVnVJaXdpWlhod0lqb3hOak16TlRNNE5EQTRmUS5lRjh5a1BIVjY4M0FyaFA2MzZUdlNLQ2tDSUxfWEJEX2tFSENfLVJKVHhnIiwidGFyZ2V0TGlua1VyaSI6Imh0dHBzOi8vZ29sZGlsb2Nrcy5sdW1lbmxlYXJuaW5nLmNvbS9zdHVkeV9wbGFuLzdjM2EzOTE1LWZmZGEtNGU4Ny05MTQ5LTE2YzFhYzUyM2IyZj9laWQ9YUd3d0x3QndrdFpnelp0cENKWGVaZyIsImNsaWVudElkIjoiOTcxNDAwMDAwMDAwMDAyMzAiLCJsdGlEZXBsb3ltZW50SWQiOiI0NjE6NTQ0MGEwODQyMmFiMWVlNzc5NGEwNTg4YjVlNGNiNGEwOTRjNDI1NiIsImNvbnRyb2xsZXIiOiIvb2lkYy9sb2dpbl9pbml0aWF0aW9ucyJ9.MyLodskYaqWNDqMbjQpmB8izEEfGRAI58KvMqtaXtkP0RL9SKFLV8hTOHPZsDhgmgGTDL71wRa6kxLEEBiXImDMDSpgkTZIgB3vf1vBmcBz03zZWa0uHHVlyLxQwWJTB65E-w6RlxJuM9wphxUVpdvRXhBr1jHiVKGdgFOm2MkJNKMOdEIQ7sT1l7anTElvcEOtYt7KqSxLFPDRORvSf1Pv3gbY5_IBR1SjLZw3h788_BFH9QSqU4yhJxHdn-tFBoycdnjJ9qqtFor6m7m44U76kDpjCU3b5XLFWOogqbb8sbTLgfwLk0-UFQTENOOUiWih1wA6Fk66vuMX3yHXUOw";
+    private static String ID_TOKEN = "eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsImtpZCI6IjIwMjEtMDktMDFUMDA6MTQ6MzdaIn0.eyJodHRwczovL3B1cmwuaW1zZ2xvYmFsLm9yZy9zcGVjL2x0aS9jbGFpbS9tZXNzYWdlX3R5cGUiOiJMdGlSZXNvdXJjZUxpbmtSZXF1ZXN0IiwiaHR0cHM6Ly9wdXJsLmltc2dsb2JhbC5vcmcvc3BlYy9sdGkvY2xhaW0vdmVyc2lvbiI6IjEuMy4wIiwiaHR0cHM6Ly9wdXJsLmltc2dsb2JhbC5vcmcvc3BlYy9sdGkvY2xhaW0vcmVzb3VyY2VfbGluayI6eyJpZCI6IjcxZTViNWNiLTZmMDUtNGQ1My1iN2U5LWQxMmVjZDQ3NWU3NiIsImRlc2NyaXB0aW9uIjoiIiwidGl0bGUiOiJTdHVkeSBQbGFuOiBUaGUgRXRpb2xvZ3kgYW5kIFRyZWF0bWVudCBvZiBNZW50YWwgRGlzb3JkZXJzIiwidmFsaWRhdGlvbl9jb250ZXh0IjpudWxsLCJlcnJvcnMiOnsiZXJyb3JzIjp7fX19LCJhdWQiOiI5NzE0MDAwMDAwMDAwMDIzMCIsImF6cCI6Ijk3MTQwMDAwMDAwMDAwMjMwIiwiaHR0cHM6Ly9wdXJsLmltc2dsb2JhbC5vcmcvc3BlYy9sdGkvY2xhaW0vZGVwbG95bWVudF9pZCI6IjQ2MTo1NDQwYTA4NDIyYWIxZWU3Nzk0YTA1ODhiNWU0Y2I0YTA5NGM0MjU2IiwiZXhwIjoxNjMzNTQyMzczLCJpYXQiOjE2MzM1Mzg3NzMsImlzcyI6Imh0dHBzOi8vY2FudmFzLmluc3RydWN0dXJlLmNvbSIsIm5vbmNlIjoiNWQwNGNiMTJmNDVkZjZlZTM3M2M0MmExY2E0Y2RiZTA4ZTJiZmE4ZTVmN2M2NjJhY2EzZjY1NjA2ODdmZGM0NyIsInN1YiI6IjRmM2QxMmRmLWUxYWUtNDg0Zi04YjlhLWI2Njc4NjRlODEwMCIsImh0dHBzOi8vcHVybC5pbXNnbG9iYWwub3JnL3NwZWMvbHRpL2NsYWltL3RhcmdldF9saW5rX3VyaSI6Imh0dHBzOi8vZ29sZGlsb2Nrcy5sdW1lbmxlYXJuaW5nLmNvbS9zdHVkeV9wbGFuLzdjM2EzOTE1LWZmZGEtNGU4Ny05MTQ5LTE2YzFhYzUyM2IyZj9laWQ9YUd3d0x3QndrdFpnelp0cENKWGVaZyIsImh0dHBzOi8vcHVybC5pbXNnbG9iYWwub3JnL3NwZWMvbHRpL2NsYWltL2NvbnRleHQiOnsiaWQiOiIwYTQ3ZGU5MWNmODRlZTE0N2Y2ZTUzNDE5NTk4ODUwODUwNGQzZTgyIiwibGFiZWwiOiJtZ3dvemR6LWx1bWVuIiwidGl0bGUiOiJtZ3dvemR6IEx1bWVuIFRlc3QiLCJ0eXBlIjpbImh0dHA6Ly9wdXJsLmltc2dsb2JhbC5vcmcvdm9jYWIvbGlzL3YyL2NvdXJzZSNDb3Vyc2VPZmZlcmluZyJdLCJ2YWxpZGF0aW9uX2NvbnRleHQiOm51bGwsImVycm9ycyI6eyJlcnJvcnMiOnt9fX0sImh0dHBzOi8vcHVybC5pbXNnbG9iYWwub3JnL3NwZWMvbHRpL2NsYWltL3Rvb2xfcGxhdGZvcm0iOnsiZ3VpZCI6InBvdDI4eU5wRFNaczFGdk1RYTQyTWlQV2xST0xRQ0FlZHpRWDZNYzI6Y2FudmFzLWxtcyIsIm5hbWUiOiJVbmljb24iLCJ2ZXJzaW9uIjoiY2xvdWQiLCJwcm9kdWN0X2ZhbWlseV9jb2RlIjoiY2FudmFzIiwidmFsaWRhdGlvbl9jb250ZXh0IjpudWxsLCJlcnJvcnMiOnsiZXJyb3JzIjp7fX19LCJodHRwczovL3B1cmwuaW1zZ2xvYmFsLm9yZy9zcGVjL2x0aS9jbGFpbS9sYXVuY2hfcHJlc2VudGF0aW9uIjp7ImRvY3VtZW50X3RhcmdldCI6ImlmcmFtZSIsImhlaWdodCI6bnVsbCwid2lkdGgiOm51bGwsInJldHVybl91cmwiOiJodHRwczovL3VuaWNvbi5pbnN0cnVjdHVyZS5jb20vY291cnNlcy8zMzQ4L2V4dGVybmFsX2NvbnRlbnQvc3VjY2Vzcy9leHRlcm5hbF90b29sX3JlZGlyZWN0IiwibG9jYWxlIjoiZW4iLCJ2YWxpZGF0aW9uX2NvbnRleHQiOm51bGwsImVycm9ycyI6eyJlcnJvcnMiOnt9fX0sImxvY2FsZSI6ImVuIiwiaHR0cHM6Ly9wdXJsLmltc2dsb2JhbC5vcmcvc3BlYy9sdGkvY2xhaW0vcm9sZXMiOlsiaHR0cDovL3B1cmwuaW1zZ2xvYmFsLm9yZy92b2NhYi9saXMvdjIvaW5zdGl0dXRpb24vcGVyc29uI0FkbWluaXN0cmF0b3IiLCJodHRwOi8vcHVybC5pbXNnbG9iYWwub3JnL3ZvY2FiL2xpcy92Mi9pbnN0aXR1dGlvbi9wZXJzb24jSW5zdHJ1Y3RvciIsImh0dHA6Ly9wdXJsLmltc2dsb2JhbC5vcmcvdm9jYWIvbGlzL3YyL2luc3RpdHV0aW9uL3BlcnNvbiNTdHVkZW50IiwiaHR0cDovL3B1cmwuaW1zZ2xvYmFsLm9yZy92b2NhYi9saXMvdjIvbWVtYmVyc2hpcCNJbnN0cnVjdG9yIiwiaHR0cDovL3B1cmwuaW1zZ2xvYmFsLm9yZy92b2NhYi9saXMvdjIvc3lzdGVtL3BlcnNvbiNVc2VyIl0sImh0dHBzOi8vcHVybC5pbXNnbG9iYWwub3JnL3NwZWMvbHRpL2NsYWltL2N1c3RvbSI6eyJkdWVfYXQiOiIkQ2FudmFzLmFzc2lnbm1lbnQuZHVlQXQuaXNvODYwMSIsImxvY2tfYXQiOiIkQ2FudmFzLmFzc2lnbm1lbnQubG9ja0F0Lmlzbzg2MDEiLCJ1bmxvY2tfYXQiOiIkQ2FudmFzLmFzc2lnbm1lbnQudW5sb2NrQXQuaXNvODYwMSIsImNhbnZhc191c2VyX2lkIjozODYsImNhbnZhc19sb2dpbl9pZCI6Im1nd296ZHpAdW5pY29uLm5ldCIsImNhbnZhc19jb3Vyc2VfaWQiOjMzNDgsImNhbnZhc191c2VyX25hbWUiOiJtZ3dvemR6QHVuaWNvbi5uZXQiLCJjYW52YXNfYXNzaWdubWVudF9pZCI6NjI3MX0sImh0dHBzOi8vcHVybC5pbXNnbG9iYWwub3JnL3NwZWMvbHRpL2NsYWltL2x0aTExX2xlZ2FjeV91c2VyX2lkIjoiNDA3YTQxODI1MDdmMGYzN2E1NGVjNTVkNTAxOTM5YzFkM2QxMDJlNiIsImh0dHBzOi8vcHVybC5pbXNnbG9iYWwub3JnL3NwZWMvbHRpL2NsYWltL2x0aTFwMSI6eyJ1c2VyX2lkIjoiNDA3YTQxODI1MDdmMGYzN2E1NGVjNTVkNTAxOTM5YzFkM2QxMDJlNiIsInZhbGlkYXRpb25fY29udGV4dCI6bnVsbCwiZXJyb3JzIjp7ImVycm9ycyI6e319fSwiZXJyb3JzIjp7ImVycm9ycyI6e319LCJodHRwczovL3B1cmwuaW1zZ2xvYmFsLm9yZy9zcGVjL2x0aS1hZ3MvY2xhaW0vZW5kcG9pbnQiOnsic2NvcGUiOlsiaHR0cHM6Ly9wdXJsLmltc2dsb2JhbC5vcmcvc3BlYy9sdGktYWdzL3Njb3BlL2xpbmVpdGVtIiwiaHR0cHM6Ly9wdXJsLmltc2dsb2JhbC5vcmcvc3BlYy9sdGktYWdzL3Njb3BlL2xpbmVpdGVtLnJlYWRvbmx5IiwiaHR0cHM6Ly9wdXJsLmltc2dsb2JhbC5vcmcvc3BlYy9sdGktYWdzL3Njb3BlL3Jlc3VsdC5yZWFkb25seSIsImh0dHBzOi8vcHVybC5pbXNnbG9iYWwub3JnL3NwZWMvbHRpLWFncy9zY29wZS9zY29yZSJdLCJsaW5laXRlbXMiOiJodHRwczovL3VuaWNvbi5pbnN0cnVjdHVyZS5jb20vYXBpL2x0aS9jb3Vyc2VzLzMzNDgvbGluZV9pdGVtcyIsImxpbmVpdGVtIjoiaHR0cHM6Ly91bmljb24uaW5zdHJ1Y3R1cmUuY29tL2FwaS9sdGkvY291cnNlcy8zMzQ4L2xpbmVfaXRlbXMvNTAzIiwidmFsaWRhdGlvbl9jb250ZXh0IjpudWxsLCJlcnJvcnMiOnsiZXJyb3JzIjp7fX19LCJwaWN0dXJlIjoiaHR0cHM6Ly9jYW52YXMuaW5zdHJ1Y3R1cmUuY29tL2ltYWdlcy9tZXNzYWdlcy9hdmF0YXItNTAucG5nIiwiZW1haWwiOiJtZ3dvemR6QHVuaWNvbi5uZXQiLCJuYW1lIjoiTWFyeSBHd296ZHoiLCJnaXZlbl9uYW1lIjoiTWFyeSIsImZhbWlseV9uYW1lIjoiR3dvemR6IiwiaHR0cHM6Ly9wdXJsLmltc2dsb2JhbC5vcmcvc3BlYy9sdGkvY2xhaW0vbGlzIjp7InBlcnNvbl9zb3VyY2VkaWQiOiJtZ3dvemR6IiwiY291cnNlX29mZmVyaW5nX3NvdXJjZWRpZCI6bnVsbCwidmFsaWRhdGlvbl9jb250ZXh0IjpudWxsLCJlcnJvcnMiOnsiZXJyb3JzIjp7fX19LCJodHRwczovL3B1cmwuaW1zZ2xvYmFsLm9yZy9zcGVjL2x0aS1ucnBzL2NsYWltL25hbWVzcm9sZXNlcnZpY2UiOnsiY29udGV4dF9tZW1iZXJzaGlwc191cmwiOiJodHRwczovL3VuaWNvbi5pbnN0cnVjdHVyZS5jb20vYXBpL2x0aS9jb3Vyc2VzLzMzNDgvbmFtZXNfYW5kX3JvbGVzIiwic2VydmljZV92ZXJzaW9ucyI6WyIyLjAiXSwidmFsaWRhdGlvbl9jb250ZXh0IjpudWxsLCJlcnJvcnMiOnsiZXJyb3JzIjp7fX19LCJodHRwczovL3d3dy5pbnN0cnVjdHVyZS5jb20vcGxhY2VtZW50IjpudWxsfQ.qN6MqcitF8VHuMVk_YmuXnKN43A1TgdjbSV8zHxT6SS5uZo8vtTB2GBGmqPpsknTmJPNijpQsPMoeLN3kKAvkpJ0RJPWMYud89a1SGnons8HuqXxACUCwUa7Lki8j7xSIXB6tgXQqzkrHCPmsBwLQy6rAYseiDNpsLkzIZzBAZjt89262i_UxRScJkhdPF4GEQDw4d2d1YMM5cmSy039BZZyT7AOV4q3qjo_BeFlQ5QJjXDtXGZ5VIcOuyLipAcrG8a2llXd8gLDkxkD0gIwI_zZX2fG-XKHc_co_gp45L2fVz09vKS5R-yCiooZgktOBoe0OEY8vHfCbBk4Vj2sxg";
+
+    @InjectMocks
+    private LTI3Controller lti3Controller = new LTI3Controller();
+
+    @MockBean
+    private LTIJWTService ltijwtService;
+
+    @MockBean
+    private APIJWTService apijwtService;
+
+    @MockBean
+    private LtiLinkRepository ltiLinkRepository;
+
+    @MockBean
+    private LTIDataService ltiDataService;
+
+    @MockBean
+    private LtiContextRepository ltiContextRepository;
+
+    @Mock
+    private HttpServletRequest req;
+
+    private Model model = new ExtendedModelMap();
+
+    @Mock
+    Jws<Claims> jwsClaims;
+
+    @Mock
+    Claims claims;
+
+    @Mock
+    LTI3Request lti3Request;
+
+    @Mock
+    LtiContextEntity ltiContextEntity;
+
+    private static MockedStatic<LTI3Request> lti3RequestMockedStatic;
+
+    @Configuration
+    static class ContextConfiguration {
+
+    }
+
+    @BeforeEach
+    public void setUp() {
+        MockitoAnnotations.openMocks(this);
+        lti3RequestMockedStatic = Mockito.mockStatic(LTI3Request.class);
+        when(req.getParameter("state")).thenReturn(VALID_STATE);
+        when(req.getParameter("link")).thenReturn("https://tool.com/test");
+        when(req.getParameter("id_token")).thenReturn(ID_TOKEN);
+        when(jwsClaims.getBody()).thenReturn(claims);
+        when(ltijwtService.validateState(VALID_STATE)).thenReturn(jwsClaims);
+        lti3RequestMockedStatic.when(() -> LTI3Request.getInstance("https://tool.com/test")).thenReturn(lti3Request);
+    }
+
+    @AfterEach
+    public void close() {
+        lti3RequestMockedStatic.close();
+    }
+
+    @Test
+    public void testLTI3InvalidClientId() {
+        try {
+            when(claims.get("clientId")).thenReturn("client-id-1");
+            when(lti3Request.getAud()).thenReturn("bad-client-id");
+
+            String response = lti3Controller.lti3(req, model);
+
+            Mockito.verify(ltijwtService).validateState(VALID_STATE);
+            assertEquals(response, TextConstants.LTI3ERROR);
+            assertEquals(model.getAttribute(TextConstants.ERROR), "Invalid Client Id");
+        } catch (DataServiceException | ConnectionException e) {
+            fail("Exception should not be thrown.");
+        }
+    }
+
+    @Test
+    public void testLTI3InvalidDeploymentIdAndValidClientId() {
+        try {
+            when(claims.get("clientId")).thenReturn("client-id-1");
+            when(claims.get("ltiDeploymentId")).thenReturn("deployment-id-1");
+            when(lti3Request.getAud()).thenReturn("client-id-1");
+            when(lti3Request.getLtiDeploymentId()).thenReturn("bad-deployment-id");
+
+            String response = lti3Controller.lti3(req, model);
+
+            Mockito.verify(ltijwtService).validateState(VALID_STATE);
+            assertEquals(response, TextConstants.LTI3ERROR);
+            assertEquals(model.getAttribute(TextConstants.ERROR), "Invalid Deployment Id");
+        } catch (DataServiceException | ConnectionException e) {
+            fail("Exception should not be thrown.");
+        }
+    }
+
+    @Test
+    public void testLTI3DemoModeOff() {
+        try {
+            when(claims.get("clientId")).thenReturn("client-id-1");
+            when(claims.get("ltiDeploymentId")).thenReturn("deployment-id-1");
+            when(lti3Request.getAud()).thenReturn("client-id-1");
+            when(lti3Request.getLtiDeploymentId()).thenReturn("deployment-id-1");
+            when(ltiDataService.getDemoMode()).thenReturn(false);
+            when(lti3Request.getLtiTargetLinkUrl()).thenReturn("https://tool.com/test");
+
+            KeyPairGenerator kpg = KeyPairGenerator.getInstance("RSA");
+            kpg.initialize(1024);
+            KeyPair kp = kpg.generateKeyPair();
+            Base64.Encoder encoder = Base64.getEncoder();
+            String privateKey = "-----BEGIN PRIVATE KEY-----\n" + encoder.encodeToString(kp.getPrivate().getEncoded()) + "\n-----END PRIVATE KEY-----\n";
+            when(ltiDataService.getOwnPrivateKey()).thenReturn(privateKey);
+            when(lti3Request.getClaims()).thenReturn(claims);
+
+            String response = lti3Controller.lti3(req, model);
+
+            Mockito.verify(ltijwtService).validateState(VALID_STATE);
+            Mockito.verify(ltiDataService).getDemoMode();
+            Mockito.verify(apijwtService).buildJwt(eq(true), eq(lti3Request));
+            assertTrue(response.contains("redirect:/app/app.html?token="));
+
+        } catch (DataServiceException | ConnectionException | GeneralSecurityException | IOException e) {
+            fail("Exception should not be thrown.");
+        }
+    }
+
+    @Test
+    public void testLTI3DemoModeOffWithoutClientIdOrDeploymentIdInState() {
+        try {
+            when(claims.get("clientId")).thenReturn(null);
+            when(claims.get("ltiDeploymentId")).thenReturn(null);
+            when(lti3Request.getAud()).thenReturn("client-id-1");
+            when(lti3Request.getLtiDeploymentId()).thenReturn("deployment-id-1");
+            when(ltiDataService.getDemoMode()).thenReturn(false);
+            when(lti3Request.getLtiTargetLinkUrl()).thenReturn("https://tool.com/test");
+
+            KeyPairGenerator kpg = KeyPairGenerator.getInstance("RSA");
+            kpg.initialize(1024);
+            KeyPair kp = kpg.generateKeyPair();
+            Base64.Encoder encoder = Base64.getEncoder();
+            String privateKey = "-----BEGIN PRIVATE KEY-----\n" + encoder.encodeToString(kp.getPrivate().getEncoded()) + "\n-----END PRIVATE KEY-----\n";
+            when(ltiDataService.getOwnPrivateKey()).thenReturn(privateKey);
+            when(lti3Request.getClaims()).thenReturn(claims);
+
+            String response = lti3Controller.lti3(req, model);
+
+            Mockito.verify(ltijwtService).validateState(VALID_STATE);
+            Mockito.verify(ltiDataService).getDemoMode();
+            Mockito.verify(apijwtService).buildJwt(eq(true), eq(lti3Request));
+            assertTrue(response.contains("redirect:/app/app.html?token="));
+
+        } catch (DataServiceException | ConnectionException | GeneralSecurityException | IOException e) {
+            fail("Exception should not be thrown.");
+        }
+    }
+
+    @Test
+    public void testLTI3DemoModeOn() {
+        try {
+            when(claims.get("clientId")).thenReturn("client-id-1");
+            when(claims.get("ltiDeploymentId")).thenReturn("deployment-id-1");
+            when(lti3Request.getAud()).thenReturn("client-id-1");
+            when(lti3Request.getLtiDeploymentId()).thenReturn("deployment-id-1");
+            when(lti3Request.getContext()).thenReturn(ltiContextEntity);
+            when(lti3Request.getLtiMessageType()).thenReturn(LtiStrings.LTI_MESSAGE_TYPE_RESOURCE_LINK);
+            when(ltiDataService.getDemoMode()).thenReturn(true);
+
+            String finalResponse = lti3Controller.lti3(req, model);
+
+            Mockito.verify(ltijwtService).validateState(VALID_STATE);
+            Mockito.verify(ltiDataService).getDemoMode();
+            assertEquals(finalResponse, "lti3Result");
+
+        } catch (DataServiceException | ConnectionException e) {
+            fail("Exception should not be thrown.");
+        }
+    }
+}

--- a/src/test/java/net/unicon/lti/controller/lti/OIDCControllerTest.java
+++ b/src/test/java/net/unicon/lti/controller/lti/OIDCControllerTest.java
@@ -1,0 +1,409 @@
+package net.unicon.lti.controller.lti;
+
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.Jws;
+import io.jsonwebtoken.Jwts;
+import net.unicon.lti.model.PlatformDeployment;
+import net.unicon.lti.repository.PlatformDeploymentRepository;
+import net.unicon.lti.service.lti.LTIDataService;
+import net.unicon.lti.utils.TextConstants;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.MockitoAnnotations;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.mock.web.MockHttpSession;
+import org.springframework.ui.ExtendedModelMap;
+import org.springframework.ui.Model;
+import org.springframework.util.MultiValueMap;
+import org.springframework.web.util.UriComponents;
+import org.springframework.web.util.UriComponentsBuilder;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import java.security.KeyPair;
+import java.security.KeyPairGenerator;
+import java.security.NoSuchAlgorithmException;
+import java.util.Arrays;
+import java.util.Base64;
+import java.util.List;
+
+import static net.unicon.lti.utils.LtiStrings.OIDC_CLIENT_ID;
+import static net.unicon.lti.utils.LtiStrings.OIDC_DEPLOYMENT_ID;
+import static net.unicon.lti.utils.LtiStrings.OIDC_FORM_POST;
+import static net.unicon.lti.utils.LtiStrings.OIDC_ID_TOKEN;
+import static net.unicon.lti.utils.LtiStrings.OIDC_ISS;
+import static net.unicon.lti.utils.LtiStrings.OIDC_LOGIN_HINT;
+import static net.unicon.lti.utils.LtiStrings.OIDC_LTI_MESSAGE_HINT;
+import static net.unicon.lti.utils.LtiStrings.OIDC_NONE;
+import static net.unicon.lti.utils.LtiStrings.OIDC_OPEN_ID;
+import static net.unicon.lti.utils.LtiStrings.OIDC_TARGET_LINK_URI;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.when;
+
+@WebMvcTest(LTI3Controller.class)
+public class OIDCControllerTest {
+    private static final String SAMPLE_LOGIN_HINT = "sample-login-hint-from-platform";
+    private static final String SAMPLE_TARGET_URI = "https://lti-tool.com/lti3";
+    private static final String SAMPLE_LTI_MESSAGE_HINT = "sample-message-hint-from-platform";
+    private static final String SAMPLE_ISS = "https://platform-lms.com";
+    private static final String SAMPLE_CLIENT_ID = "sample-client-id";
+    private static final String SAMPLE_DEPLOYMENT_ID = "sample-deployment-id";
+    private static final String SAMPLE_DEPLOYMENT_ID2 = "sample-deployment-id-2";
+    private static final String SAMPLE_OIDC_ENDPOINT = "https://platform-lms.com/oidc";
+    private static final String SAMPLE_ENCODED_REDIRECT_URI = "https%3A%2F%2Flti-tool.com%2Flti3%2F";
+
+
+    @InjectMocks
+    private OIDCController oidcController = new OIDCController();
+
+    @MockBean
+    private PlatformDeploymentRepository platformDeploymentRepository;
+
+    @MockBean
+    private LTIDataService ltiDataService;
+
+    @Mock
+    private HttpServletRequest req;
+
+    @Mock
+    private HttpServletResponse res;
+
+    @Mock
+    private PlatformDeployment platformDeployment1;
+
+    @Mock
+    private PlatformDeployment platformDeployment2;
+
+    private MockHttpSession mockHttpSession = new MockHttpSession();
+
+    private List<PlatformDeployment> onePlatformDeployment;
+    private List<PlatformDeployment> multiplePlatformDeployments;
+
+    private KeyPair kp;
+
+    private Model model = new ExtendedModelMap();
+
+    @Configuration
+    static class ContextConfiguration {
+
+    }
+
+    @BeforeEach
+    public void setUp() {
+        MockitoAnnotations.openMocks(this);
+        onePlatformDeployment = Arrays.asList(platformDeployment1);
+        multiplePlatformDeployments = Arrays.asList(platformDeployment1, platformDeployment2);
+        when(req.getParameter(OIDC_LOGIN_HINT)).thenReturn(SAMPLE_LOGIN_HINT);
+        when(req.getParameter(OIDC_TARGET_LINK_URI)).thenReturn(SAMPLE_TARGET_URI);
+        when(req.getParameter(OIDC_LTI_MESSAGE_HINT)).thenReturn(SAMPLE_LTI_MESSAGE_HINT);
+        when(ltiDataService.getDemoMode()).thenReturn(false);
+        when(req.getSession()).thenReturn(mockHttpSession);
+        when(ltiDataService.getLocalUrl()).thenReturn("https://lti-tool.com");
+        when(platformDeployment1.getClientId()).thenReturn(SAMPLE_CLIENT_ID);
+        when(platformDeployment2.getClientId()).thenReturn(SAMPLE_CLIENT_ID);
+        when(platformDeployment1.getDeploymentId()).thenReturn(SAMPLE_DEPLOYMENT_ID);
+        when(platformDeployment2.getDeploymentId()).thenReturn(SAMPLE_DEPLOYMENT_ID2);
+        when(platformDeployment1.getOidcEndpoint()).thenReturn(SAMPLE_OIDC_ENDPOINT);
+        when(platformDeployment2.getOidcEndpoint()).thenReturn(SAMPLE_OIDC_ENDPOINT);
+
+        try {
+            KeyPairGenerator kpg = KeyPairGenerator.getInstance("RSA");
+            kpg.initialize(1024);
+            kp = kpg.generateKeyPair();
+            Base64.Encoder encoder = Base64.getEncoder();
+            String privateKey = "-----BEGIN PRIVATE KEY-----\n" + encoder.encodeToString(kp.getPrivate().getEncoded()) + "\n-----END PRIVATE KEY-----\n";
+            when(ltiDataService.getOwnPrivateKey()).thenReturn(privateKey);
+        } catch(NoSuchAlgorithmException e) {
+            fail();
+        }
+    }
+
+    @Test
+    public void testLoginInitiationWithIssuerAndClientIdAndDeploymentIdOneConfig() {
+        when(req.getParameter(OIDC_ISS)).thenReturn(SAMPLE_ISS);
+        when(req.getParameter(OIDC_CLIENT_ID)).thenReturn(SAMPLE_CLIENT_ID);
+        when(req.getParameter(OIDC_DEPLOYMENT_ID)).thenReturn(SAMPLE_DEPLOYMENT_ID);
+        when(req.getParameter(OIDC_TARGET_LINK_URI)).thenReturn(SAMPLE_TARGET_URI);
+        when(req.getParameter(OIDC_LTI_MESSAGE_HINT)).thenReturn(SAMPLE_LTI_MESSAGE_HINT);
+        when(req.getParameter(OIDC_LOGIN_HINT)).thenReturn(SAMPLE_LOGIN_HINT);
+        when(platformDeploymentRepository.findByIssAndClientIdAndDeploymentId(any(String.class), any(String.class), any(String.class)))
+                .thenReturn(onePlatformDeployment);
+
+        String response = oidcController.loginInitiations(req, model);
+
+        Mockito.verify(platformDeploymentRepository).findByIssAndClientIdAndDeploymentId(eq(SAMPLE_ISS), eq(SAMPLE_CLIENT_ID), eq(SAMPLE_DEPLOYMENT_ID));
+        Mockito.verify(platformDeploymentRepository, never()).findByIssAndClientId(eq(SAMPLE_ISS), eq(SAMPLE_CLIENT_ID));
+        Mockito.verify(platformDeploymentRepository, never()).findByIssAndDeploymentId(eq(SAMPLE_ISS), eq(SAMPLE_DEPLOYMENT_ID));
+        Mockito.verify(platformDeploymentRepository, never()).findByIss(eq(SAMPLE_ISS));
+        Mockito.verify(req).getSession();
+        Mockito.verify(ltiDataService).getLocalUrl();
+        Mockito.verify(ltiDataService).getOwnPrivateKey();
+
+        validateOAuthResponse(response, SAMPLE_CLIENT_ID, SAMPLE_DEPLOYMENT_ID, SAMPLE_ISS);
+    }
+
+    @Test
+    public void testLoginInitiationWithIssuerAndClientIdAndDeploymentIdMultipleConfigs() {
+        when(req.getParameter(OIDC_ISS)).thenReturn(SAMPLE_ISS);
+        when(req.getParameter(OIDC_CLIENT_ID)).thenReturn(SAMPLE_CLIENT_ID);
+        when(req.getParameter(OIDC_DEPLOYMENT_ID)).thenReturn(SAMPLE_DEPLOYMENT_ID);
+        when(req.getParameter(OIDC_TARGET_LINK_URI)).thenReturn(SAMPLE_TARGET_URI);
+        when(req.getParameter(OIDC_LTI_MESSAGE_HINT)).thenReturn(SAMPLE_LTI_MESSAGE_HINT);
+        when(req.getParameter(OIDC_LOGIN_HINT)).thenReturn(SAMPLE_LOGIN_HINT);
+        when(platformDeploymentRepository.findByIssAndClientIdAndDeploymentId(any(String.class), any(String.class), any(String.class)))
+                .thenReturn(multiplePlatformDeployments);
+
+        String response = oidcController.loginInitiations(req, model);
+
+        Mockito.verify(platformDeploymentRepository).findByIssAndClientIdAndDeploymentId(eq(SAMPLE_ISS), eq(SAMPLE_CLIENT_ID), eq(SAMPLE_DEPLOYMENT_ID));
+        Mockito.verify(platformDeploymentRepository, never()).findByIssAndClientId(eq(SAMPLE_ISS), eq(SAMPLE_CLIENT_ID));
+        Mockito.verify(platformDeploymentRepository, never()).findByIssAndDeploymentId(eq(SAMPLE_ISS), eq(SAMPLE_DEPLOYMENT_ID));
+        Mockito.verify(platformDeploymentRepository, never()).findByIss(eq(SAMPLE_ISS));
+        Mockito.verify(req).getSession();
+        Mockito.verify(ltiDataService).getLocalUrl();
+        Mockito.verify(ltiDataService).getOwnPrivateKey();
+
+        validateOAuthResponse(response, SAMPLE_CLIENT_ID, SAMPLE_DEPLOYMENT_ID, SAMPLE_ISS);
+    }
+
+    @Test
+    public void testLoginInitiationWithIssuerAndClientIdOneConfig() {
+        when(req.getParameter(OIDC_ISS)).thenReturn(SAMPLE_ISS);
+        when(req.getParameter(OIDC_CLIENT_ID)).thenReturn(SAMPLE_CLIENT_ID);
+        when(req.getParameter(OIDC_DEPLOYMENT_ID)).thenReturn(null);
+        when(req.getParameter(OIDC_TARGET_LINK_URI)).thenReturn(SAMPLE_TARGET_URI);
+        when(req.getParameter(OIDC_LTI_MESSAGE_HINT)).thenReturn(SAMPLE_LTI_MESSAGE_HINT);
+        when(req.getParameter(OIDC_LOGIN_HINT)).thenReturn(SAMPLE_LOGIN_HINT);
+        when(platformDeploymentRepository.findByIssAndClientId(eq(SAMPLE_ISS), eq(SAMPLE_CLIENT_ID)))
+                .thenReturn(onePlatformDeployment);
+
+        String response = oidcController.loginInitiations(req, model);
+
+        Mockito.verify(platformDeploymentRepository, never()).findByIssAndClientIdAndDeploymentId(eq(SAMPLE_ISS), eq(SAMPLE_CLIENT_ID), eq(SAMPLE_DEPLOYMENT_ID));
+        Mockito.verify(platformDeploymentRepository).findByIssAndClientId(eq(SAMPLE_ISS), eq(SAMPLE_CLIENT_ID));
+        Mockito.verify(platformDeploymentRepository, never()).findByIssAndDeploymentId(eq(SAMPLE_ISS), eq(SAMPLE_DEPLOYMENT_ID));
+        Mockito.verify(platformDeploymentRepository, never()).findByIss(eq(SAMPLE_ISS));
+        Mockito.verify(req).getSession();
+        Mockito.verify(ltiDataService).getLocalUrl();
+        Mockito.verify(ltiDataService).getOwnPrivateKey();
+
+        validateOAuthResponse(response, SAMPLE_CLIENT_ID, SAMPLE_DEPLOYMENT_ID, SAMPLE_ISS);
+    }
+
+    @Test
+    public void testLoginInitiationWithIssuerAndClientIdMultipleConfigs() {
+        when(req.getParameter(OIDC_ISS)).thenReturn(SAMPLE_ISS);
+        when(req.getParameter(OIDC_CLIENT_ID)).thenReturn(SAMPLE_CLIENT_ID);
+        when(req.getParameter(OIDC_DEPLOYMENT_ID)).thenReturn(null);
+        when(req.getParameter(OIDC_TARGET_LINK_URI)).thenReturn(SAMPLE_TARGET_URI);
+        when(req.getParameter(OIDC_LTI_MESSAGE_HINT)).thenReturn(SAMPLE_LTI_MESSAGE_HINT);
+        when(req.getParameter(OIDC_LOGIN_HINT)).thenReturn(SAMPLE_LOGIN_HINT);
+        when(platformDeploymentRepository.findByIssAndClientId(eq(SAMPLE_ISS), eq(SAMPLE_CLIENT_ID)))
+                .thenReturn(multiplePlatformDeployments);
+
+        String response = oidcController.loginInitiations(req, model);
+
+        Mockito.verify(platformDeploymentRepository, never()).findByIssAndClientIdAndDeploymentId(eq(SAMPLE_ISS), eq(SAMPLE_CLIENT_ID), eq(SAMPLE_DEPLOYMENT_ID));
+        Mockito.verify(platformDeploymentRepository).findByIssAndClientId(eq(SAMPLE_ISS), eq(SAMPLE_CLIENT_ID));
+        Mockito.verify(platformDeploymentRepository, never()).findByIssAndDeploymentId(eq(SAMPLE_ISS), eq(SAMPLE_DEPLOYMENT_ID));
+        Mockito.verify(platformDeploymentRepository, never()).findByIss(eq(SAMPLE_ISS));
+        Mockito.verify(req).getSession();
+        Mockito.verify(ltiDataService).getLocalUrl();
+        Mockito.verify(ltiDataService).getOwnPrivateKey();
+
+        validateOAuthResponse(response, SAMPLE_CLIENT_ID, null, SAMPLE_ISS);
+    }
+
+    @Test
+    public void testLoginInitiationWithIssuerOneConfig() {
+        when(req.getParameter(OIDC_ISS)).thenReturn(SAMPLE_ISS);
+        when(req.getParameter(OIDC_CLIENT_ID)).thenReturn(null);
+        when(req.getParameter(OIDC_DEPLOYMENT_ID)).thenReturn(null);
+        when(req.getParameter(OIDC_TARGET_LINK_URI)).thenReturn(SAMPLE_TARGET_URI);
+        when(req.getParameter(OIDC_LTI_MESSAGE_HINT)).thenReturn(SAMPLE_LTI_MESSAGE_HINT);
+        when(req.getParameter(OIDC_LOGIN_HINT)).thenReturn(SAMPLE_LOGIN_HINT);
+        when(platformDeploymentRepository.findByIss(eq(SAMPLE_ISS)))
+                .thenReturn(onePlatformDeployment);
+
+        String response = oidcController.loginInitiations(req, model);
+
+        Mockito.verify(platformDeploymentRepository, never()).findByIssAndClientIdAndDeploymentId(eq(SAMPLE_ISS), eq(SAMPLE_CLIENT_ID), eq(SAMPLE_DEPLOYMENT_ID));
+        Mockito.verify(platformDeploymentRepository, never()).findByIssAndClientId(eq(SAMPLE_ISS), eq(SAMPLE_CLIENT_ID));
+        Mockito.verify(platformDeploymentRepository, never()).findByIssAndDeploymentId(eq(SAMPLE_ISS), eq(SAMPLE_DEPLOYMENT_ID));
+        Mockito.verify(platformDeploymentRepository).findByIss(eq(SAMPLE_ISS));
+        Mockito.verify(req).getSession();
+        Mockito.verify(ltiDataService).getLocalUrl();
+        Mockito.verify(ltiDataService).getOwnPrivateKey();
+
+        validateOAuthResponse(response, SAMPLE_CLIENT_ID, SAMPLE_DEPLOYMENT_ID, SAMPLE_ISS);
+
+    }
+
+    @Test
+    public void testLoginInitiationWithIssuerMultipleConfigs() {
+        when(req.getParameter(OIDC_ISS)).thenReturn(SAMPLE_ISS);
+        when(req.getParameter(OIDC_CLIENT_ID)).thenReturn(null);
+        when(req.getParameter(OIDC_DEPLOYMENT_ID)).thenReturn(null);
+        when(req.getParameter(OIDC_TARGET_LINK_URI)).thenReturn(SAMPLE_TARGET_URI);
+        when(req.getParameter(OIDC_LTI_MESSAGE_HINT)).thenReturn(SAMPLE_LTI_MESSAGE_HINT);
+        when(req.getParameter(OIDC_LOGIN_HINT)).thenReturn(SAMPLE_LOGIN_HINT);
+        when(platformDeploymentRepository.findByIss(eq(SAMPLE_ISS)))
+                .thenReturn(multiplePlatformDeployments);
+
+        String response = oidcController.loginInitiations(req, model);
+
+        Mockito.verify(platformDeploymentRepository, never()).findByIssAndClientIdAndDeploymentId(eq(SAMPLE_ISS), eq(SAMPLE_CLIENT_ID), eq(SAMPLE_DEPLOYMENT_ID));
+        Mockito.verify(platformDeploymentRepository, never()).findByIssAndClientId(eq(SAMPLE_ISS), eq(SAMPLE_CLIENT_ID));
+        Mockito.verify(platformDeploymentRepository, never()).findByIssAndDeploymentId(eq(SAMPLE_ISS), eq(SAMPLE_DEPLOYMENT_ID));
+        Mockito.verify(platformDeploymentRepository).findByIss(eq(SAMPLE_ISS));
+        Mockito.verify(req).getSession();
+        Mockito.verify(ltiDataService).getLocalUrl();
+        Mockito.verify(ltiDataService).getOwnPrivateKey();
+
+        validateOAuthResponse(response, null, null, SAMPLE_ISS);
+
+    }
+
+    @Test
+    public void testLoginInitiationWithIssuerAndDeploymentIdOneConfig() {
+        when(req.getParameter(OIDC_ISS)).thenReturn(SAMPLE_ISS);
+        when(req.getParameter(OIDC_CLIENT_ID)).thenReturn(null);
+        when(req.getParameter(OIDC_DEPLOYMENT_ID)).thenReturn(SAMPLE_DEPLOYMENT_ID);
+        when(req.getParameter(OIDC_TARGET_LINK_URI)).thenReturn(SAMPLE_TARGET_URI);
+        when(req.getParameter(OIDC_LTI_MESSAGE_HINT)).thenReturn(SAMPLE_LTI_MESSAGE_HINT);
+        when(req.getParameter(OIDC_LOGIN_HINT)).thenReturn(SAMPLE_LOGIN_HINT);
+        when(platformDeploymentRepository.findByIssAndDeploymentId(eq(SAMPLE_ISS), eq(SAMPLE_DEPLOYMENT_ID)))
+                .thenReturn(onePlatformDeployment);
+
+        String response = oidcController.loginInitiations(req, model);
+
+        Mockito.verify(platformDeploymentRepository, never()).findByIssAndClientIdAndDeploymentId(eq(SAMPLE_ISS), eq(SAMPLE_CLIENT_ID), eq(SAMPLE_DEPLOYMENT_ID));
+        Mockito.verify(platformDeploymentRepository, never()).findByIssAndClientId(eq(SAMPLE_ISS), eq(SAMPLE_CLIENT_ID));
+        Mockito.verify(platformDeploymentRepository).findByIssAndDeploymentId(eq(SAMPLE_ISS), eq(SAMPLE_DEPLOYMENT_ID));
+        Mockito.verify(platformDeploymentRepository, never()).findByIss(eq(SAMPLE_ISS));
+        Mockito.verify(req).getSession();
+        Mockito.verify(ltiDataService).getLocalUrl();
+        Mockito.verify(ltiDataService).getOwnPrivateKey();
+
+        validateOAuthResponse(response, SAMPLE_CLIENT_ID, SAMPLE_DEPLOYMENT_ID, SAMPLE_ISS);
+
+    }
+
+    @Test
+    public void testLoginInitiationWithIssuerAndDeploymentIdMultipleConfigs() {
+        when(req.getParameter(OIDC_ISS)).thenReturn(SAMPLE_ISS);
+        when(req.getParameter(OIDC_CLIENT_ID)).thenReturn(null);
+        when(req.getParameter(OIDC_DEPLOYMENT_ID)).thenReturn(SAMPLE_DEPLOYMENT_ID);
+        when(req.getParameter(OIDC_TARGET_LINK_URI)).thenReturn(SAMPLE_TARGET_URI);
+        when(req.getParameter(OIDC_LTI_MESSAGE_HINT)).thenReturn(SAMPLE_LTI_MESSAGE_HINT);
+        when(req.getParameter(OIDC_LOGIN_HINT)).thenReturn(SAMPLE_LOGIN_HINT);
+        when(platformDeploymentRepository.findByIssAndDeploymentId(eq(SAMPLE_ISS), eq(SAMPLE_DEPLOYMENT_ID)))
+                .thenReturn(multiplePlatformDeployments);
+
+        String response = oidcController.loginInitiations(req, model);
+
+        Mockito.verify(platformDeploymentRepository, never()).findByIssAndClientIdAndDeploymentId(eq(SAMPLE_ISS), eq(SAMPLE_CLIENT_ID), eq(SAMPLE_DEPLOYMENT_ID));
+        Mockito.verify(platformDeploymentRepository, never()).findByIssAndClientId(eq(SAMPLE_ISS), eq(SAMPLE_CLIENT_ID));
+        Mockito.verify(platformDeploymentRepository).findByIssAndDeploymentId(eq(SAMPLE_ISS), eq(SAMPLE_DEPLOYMENT_ID));
+        Mockito.verify(platformDeploymentRepository, never()).findByIss(eq(SAMPLE_ISS));
+        Mockito.verify(req).getSession();
+        Mockito.verify(ltiDataService).getLocalUrl();
+        Mockito.verify(ltiDataService).getOwnPrivateKey();
+
+        validateOAuthResponse(response, null, SAMPLE_DEPLOYMENT_ID, SAMPLE_ISS);
+
+    }
+
+    @Test
+    public void testLoginInitiationWithoutConfigIdentifiers() {
+        when(req.getParameter(OIDC_ISS)).thenReturn(null);
+        when(req.getParameter(OIDC_CLIENT_ID)).thenReturn(null);
+        when(req.getParameter(OIDC_DEPLOYMENT_ID)).thenReturn(null);
+        when(req.getParameter(OIDC_TARGET_LINK_URI)).thenReturn(SAMPLE_TARGET_URI);
+        when(req.getParameter(OIDC_LTI_MESSAGE_HINT)).thenReturn(SAMPLE_LTI_MESSAGE_HINT);
+        when(req.getParameter(OIDC_LOGIN_HINT)).thenReturn(SAMPLE_LOGIN_HINT);
+
+        String response = oidcController.loginInitiations(req, model);
+
+        Mockito.verify(platformDeploymentRepository, never()).findByIssAndClientIdAndDeploymentId(eq(null), eq(null), eq(null));
+        Mockito.verify(platformDeploymentRepository, never()).findByIssAndClientId(eq(null), eq(null));
+        Mockito.verify(platformDeploymentRepository, never()).findByIssAndDeploymentId(eq(null), eq(null));
+        Mockito.verify(platformDeploymentRepository).findByIss(eq(null));
+        Mockito.verify(req, never()).getSession();
+        Mockito.verify(ltiDataService, never()).getLocalUrl();
+        Mockito.verify(ltiDataService, never()).getOwnPrivateKey();
+
+        assertEquals(TextConstants.LTI3ERROR, response);
+    }
+
+    @Test
+    public void testLoginInitiationWithoutIss() {
+        when(req.getParameter(OIDC_ISS)).thenReturn(null);
+        when(req.getParameter(OIDC_CLIENT_ID)).thenReturn(SAMPLE_CLIENT_ID);
+        when(req.getParameter(OIDC_DEPLOYMENT_ID)).thenReturn(SAMPLE_DEPLOYMENT_ID);
+        when(req.getParameter(OIDC_TARGET_LINK_URI)).thenReturn(SAMPLE_TARGET_URI);
+        when(req.getParameter(OIDC_LTI_MESSAGE_HINT)).thenReturn(SAMPLE_LTI_MESSAGE_HINT);
+        when(req.getParameter(OIDC_LOGIN_HINT)).thenReturn(SAMPLE_LOGIN_HINT);
+
+        String response = oidcController.loginInitiations(req, model);
+
+        Mockito.verify(platformDeploymentRepository).findByIssAndClientIdAndDeploymentId(eq(null), eq(SAMPLE_CLIENT_ID), eq(SAMPLE_DEPLOYMENT_ID));
+        Mockito.verify(platformDeploymentRepository, never()).findByIssAndClientId(eq(null), eq(SAMPLE_CLIENT_ID));
+        Mockito.verify(platformDeploymentRepository, never()).findByIssAndDeploymentId(eq(null), eq(SAMPLE_DEPLOYMENT_ID));
+        Mockito.verify(platformDeploymentRepository, never()).findByIss(eq(null));
+        Mockito.verify(req, never()).getSession();
+        Mockito.verify(ltiDataService, never()).getLocalUrl();
+        Mockito.verify(ltiDataService, never()).getOwnPrivateKey();
+
+        assertEquals(TextConstants.LTI3ERROR, response);
+    }
+
+    private void validateOAuthResponse(String response, String clientId, String deploymentId, String iss) {
+        UriComponents responseUri = UriComponentsBuilder.fromUriString(response.substring("redirect:".length())).build();
+        assertEquals(SAMPLE_OIDC_ENDPOINT, responseUri.getScheme() + "://" + responseUri.getHost() + responseUri.getPath());
+        MultiValueMap<String, String> parameters = responseUri.getQueryParams();
+
+        if (clientId != null) {
+            assertEquals(clientId, parameters.get("client_id").get(0));
+        } else {
+            assertNull(parameters.get("client_id"));
+        }
+        assertEquals(SAMPLE_LOGIN_HINT, parameters.get("login_hint").get(0));
+        assertEquals(SAMPLE_LTI_MESSAGE_HINT, parameters.get("lti_message_hint").get(0));
+        assertEquals(OIDC_NONE, parameters.get("prompt").get(0));
+        assertEquals(SAMPLE_ENCODED_REDIRECT_URI, parameters.get("redirect_uri").get(0));
+        assertEquals(OIDC_FORM_POST, parameters.get("response_mode").get(0));
+        assertEquals(OIDC_ID_TOKEN, parameters.get("response_type").get(0));
+        assertEquals(OIDC_OPEN_ID, parameters.get("scope").get(0));
+        assertTrue(parameters.get("nonce").get(0).length() >= 36);
+        Jws<Claims> finalClaims = Jwts.parser().setSigningKey(kp.getPublic()).parseClaimsJws(parameters.get("state").get(0));
+        assertNotNull(finalClaims);
+        assertEquals(TextConstants.DEFAULT_KID, finalClaims.getHeader().get("kid"));
+        assertEquals("JWT", finalClaims.getHeader().get("typ"));
+        assertEquals("ltiStarter", finalClaims.getBody().getIssuer());
+        assertEquals(clientId, finalClaims.getBody().getAudience());
+        assertNotNull(finalClaims.getBody().getExpiration());
+        assertNotNull(finalClaims.getBody().getNotBefore());
+        assertNotNull(finalClaims.getBody().getIssuedAt());
+        assertNotNull(finalClaims.getBody().getId());
+        assertEquals(iss, finalClaims.getBody().get("original_iss"));
+        assertEquals(SAMPLE_LOGIN_HINT, finalClaims.getBody().get("loginHint"));
+        assertEquals(SAMPLE_LTI_MESSAGE_HINT, finalClaims.getBody().get("ltiMessageHint"));
+        assertEquals(SAMPLE_TARGET_URI, finalClaims.getBody().get("targetLinkUri"));
+        assertEquals("/oidc/login_initiations", finalClaims.getBody().get("controller"));
+        assertEquals(clientId, finalClaims.getBody().get("clientId"));
+        assertEquals(deploymentId, finalClaims.getBody().get("ltiDeploymentId"));
+    }
+}

--- a/src/test/java/net/unicon/lti/utils/lti/LTI3RequestTest.java
+++ b/src/test/java/net/unicon/lti/utils/lti/LTI3RequestTest.java
@@ -1,0 +1,208 @@
+package net.unicon.lti.utils.lti;
+
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.Jws;
+import net.unicon.lti.model.PlatformDeployment;
+import net.unicon.lti.repository.AllRepositories;
+import net.unicon.lti.repository.PlatformDeploymentRepository;
+import net.unicon.lti.service.lti.LTIDataService;
+import net.unicon.lti.utils.LtiStrings;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.mock.web.MockHttpSession;
+
+import javax.servlet.http.HttpServletRequest;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+public class LTI3RequestTest {
+    private static String ID_TOKEN = "eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsImtpZCI6IjIwMjEtMDktMDFUMDA6MTQ6MzdaIn0.eyJodHRwczovL3B1cmwuaW1zZ2xvYmFsLm9yZy9zcGVjL2x0aS9jbGFpbS9tZXNzYWdlX3R5cGUiOiJMdGlSZXNvdXJjZUxpbmtSZXF1ZXN0IiwiaHR0cHM6Ly9wdXJsLmltc2dsb2JhbC5vcmcvc3BlYy9sdGkvY2xhaW0vdmVyc2lvbiI6IjEuMy4wIiwiaHR0cHM6Ly9wdXJsLmltc2dsb2JhbC5vcmcvc3BlYy9sdGkvY2xhaW0vcmVzb3VyY2VfbGluayI6eyJpZCI6IjcxZTViNWNiLTZmMDUtNGQ1My1iN2U5LWQxMmVjZDQ3NWU3NiIsImRlc2NyaXB0aW9uIjoiIiwidGl0bGUiOiJTdHVkeSBQbGFuOiBUaGUgRXRpb2xvZ3kgYW5kIFRyZWF0bWVudCBvZiBNZW50YWwgRGlzb3JkZXJzIiwidmFsaWRhdGlvbl9jb250ZXh0IjpudWxsLCJlcnJvcnMiOnsiZXJyb3JzIjp7fX19LCJhdWQiOiI5NzE0MDAwMDAwMDAwMDIzMCIsImF6cCI6Ijk3MTQwMDAwMDAwMDAwMjMwIiwiaHR0cHM6Ly9wdXJsLmltc2dsb2JhbC5vcmcvc3BlYy9sdGkvY2xhaW0vZGVwbG95bWVudF9pZCI6IjQ2MTo1NDQwYTA4NDIyYWIxZWU3Nzk0YTA1ODhiNWU0Y2I0YTA5NGM0MjU2IiwiZXhwIjoxNjMzNTQyMzczLCJpYXQiOjE2MzM1Mzg3NzMsImlzcyI6Imh0dHBzOi8vY2FudmFzLmluc3RydWN0dXJlLmNvbSIsIm5vbmNlIjoiNWQwNGNiMTJmNDVkZjZlZTM3M2M0MmExY2E0Y2RiZTA4ZTJiZmE4ZTVmN2M2NjJhY2EzZjY1NjA2ODdmZGM0NyIsInN1YiI6IjRmM2QxMmRmLWUxYWUtNDg0Zi04YjlhLWI2Njc4NjRlODEwMCIsImh0dHBzOi8vcHVybC5pbXNnbG9iYWwub3JnL3NwZWMvbHRpL2NsYWltL3RhcmdldF9saW5rX3VyaSI6Imh0dHBzOi8vZ29sZGlsb2Nrcy5sdW1lbmxlYXJuaW5nLmNvbS9zdHVkeV9wbGFuLzdjM2EzOTE1LWZmZGEtNGU4Ny05MTQ5LTE2YzFhYzUyM2IyZj9laWQ9YUd3d0x3QndrdFpnelp0cENKWGVaZyIsImh0dHBzOi8vcHVybC5pbXNnbG9iYWwub3JnL3NwZWMvbHRpL2NsYWltL2NvbnRleHQiOnsiaWQiOiIwYTQ3ZGU5MWNmODRlZTE0N2Y2ZTUzNDE5NTk4ODUwODUwNGQzZTgyIiwibGFiZWwiOiJtZ3dvemR6LWx1bWVuIiwidGl0bGUiOiJtZ3dvemR6IEx1bWVuIFRlc3QiLCJ0eXBlIjpbImh0dHA6Ly9wdXJsLmltc2dsb2JhbC5vcmcvdm9jYWIvbGlzL3YyL2NvdXJzZSNDb3Vyc2VPZmZlcmluZyJdLCJ2YWxpZGF0aW9uX2NvbnRleHQiOm51bGwsImVycm9ycyI6eyJlcnJvcnMiOnt9fX0sImh0dHBzOi8vcHVybC5pbXNnbG9iYWwub3JnL3NwZWMvbHRpL2NsYWltL3Rvb2xfcGxhdGZvcm0iOnsiZ3VpZCI6InBvdDI4eU5wRFNaczFGdk1RYTQyTWlQV2xST0xRQ0FlZHpRWDZNYzI6Y2FudmFzLWxtcyIsIm5hbWUiOiJVbmljb24iLCJ2ZXJzaW9uIjoiY2xvdWQiLCJwcm9kdWN0X2ZhbWlseV9jb2RlIjoiY2FudmFzIiwidmFsaWRhdGlvbl9jb250ZXh0IjpudWxsLCJlcnJvcnMiOnsiZXJyb3JzIjp7fX19LCJodHRwczovL3B1cmwuaW1zZ2xvYmFsLm9yZy9zcGVjL2x0aS9jbGFpbS9sYXVuY2hfcHJlc2VudGF0aW9uIjp7ImRvY3VtZW50X3RhcmdldCI6ImlmcmFtZSIsImhlaWdodCI6bnVsbCwid2lkdGgiOm51bGwsInJldHVybl91cmwiOiJodHRwczovL3VuaWNvbi5pbnN0cnVjdHVyZS5jb20vY291cnNlcy8zMzQ4L2V4dGVybmFsX2NvbnRlbnQvc3VjY2Vzcy9leHRlcm5hbF90b29sX3JlZGlyZWN0IiwibG9jYWxlIjoiZW4iLCJ2YWxpZGF0aW9uX2NvbnRleHQiOm51bGwsImVycm9ycyI6eyJlcnJvcnMiOnt9fX0sImxvY2FsZSI6ImVuIiwiaHR0cHM6Ly9wdXJsLmltc2dsb2JhbC5vcmcvc3BlYy9sdGkvY2xhaW0vcm9sZXMiOlsiaHR0cDovL3B1cmwuaW1zZ2xvYmFsLm9yZy92b2NhYi9saXMvdjIvaW5zdGl0dXRpb24vcGVyc29uI0FkbWluaXN0cmF0b3IiLCJodHRwOi8vcHVybC5pbXNnbG9iYWwub3JnL3ZvY2FiL2xpcy92Mi9pbnN0aXR1dGlvbi9wZXJzb24jSW5zdHJ1Y3RvciIsImh0dHA6Ly9wdXJsLmltc2dsb2JhbC5vcmcvdm9jYWIvbGlzL3YyL2luc3RpdHV0aW9uL3BlcnNvbiNTdHVkZW50IiwiaHR0cDovL3B1cmwuaW1zZ2xvYmFsLm9yZy92b2NhYi9saXMvdjIvbWVtYmVyc2hpcCNJbnN0cnVjdG9yIiwiaHR0cDovL3B1cmwuaW1zZ2xvYmFsLm9yZy92b2NhYi9saXMvdjIvc3lzdGVtL3BlcnNvbiNVc2VyIl0sImh0dHBzOi8vcHVybC5pbXNnbG9iYWwub3JnL3NwZWMvbHRpL2NsYWltL2N1c3RvbSI6eyJkdWVfYXQiOiIkQ2FudmFzLmFzc2lnbm1lbnQuZHVlQXQuaXNvODYwMSIsImxvY2tfYXQiOiIkQ2FudmFzLmFzc2lnbm1lbnQubG9ja0F0Lmlzbzg2MDEiLCJ1bmxvY2tfYXQiOiIkQ2FudmFzLmFzc2lnbm1lbnQudW5sb2NrQXQuaXNvODYwMSIsImNhbnZhc191c2VyX2lkIjozODYsImNhbnZhc19sb2dpbl9pZCI6Im1nd296ZHpAdW5pY29uLm5ldCIsImNhbnZhc19jb3Vyc2VfaWQiOjMzNDgsImNhbnZhc191c2VyX25hbWUiOiJtZ3dvemR6QHVuaWNvbi5uZXQiLCJjYW52YXNfYXNzaWdubWVudF9pZCI6NjI3MX0sImh0dHBzOi8vcHVybC5pbXNnbG9iYWwub3JnL3NwZWMvbHRpL2NsYWltL2x0aTExX2xlZ2FjeV91c2VyX2lkIjoiNDA3YTQxODI1MDdmMGYzN2E1NGVjNTVkNTAxOTM5YzFkM2QxMDJlNiIsImh0dHBzOi8vcHVybC5pbXNnbG9iYWwub3JnL3NwZWMvbHRpL2NsYWltL2x0aTFwMSI6eyJ1c2VyX2lkIjoiNDA3YTQxODI1MDdmMGYzN2E1NGVjNTVkNTAxOTM5YzFkM2QxMDJlNiIsInZhbGlkYXRpb25fY29udGV4dCI6bnVsbCwiZXJyb3JzIjp7ImVycm9ycyI6e319fSwiZXJyb3JzIjp7ImVycm9ycyI6e319LCJodHRwczovL3B1cmwuaW1zZ2xvYmFsLm9yZy9zcGVjL2x0aS1hZ3MvY2xhaW0vZW5kcG9pbnQiOnsic2NvcGUiOlsiaHR0cHM6Ly9wdXJsLmltc2dsb2JhbC5vcmcvc3BlYy9sdGktYWdzL3Njb3BlL2xpbmVpdGVtIiwiaHR0cHM6Ly9wdXJsLmltc2dsb2JhbC5vcmcvc3BlYy9sdGktYWdzL3Njb3BlL2xpbmVpdGVtLnJlYWRvbmx5IiwiaHR0cHM6Ly9wdXJsLmltc2dsb2JhbC5vcmcvc3BlYy9sdGktYWdzL3Njb3BlL3Jlc3VsdC5yZWFkb25seSIsImh0dHBzOi8vcHVybC5pbXNnbG9iYWwub3JnL3NwZWMvbHRpLWFncy9zY29wZS9zY29yZSJdLCJsaW5laXRlbXMiOiJodHRwczovL3VuaWNvbi5pbnN0cnVjdHVyZS5jb20vYXBpL2x0aS9jb3Vyc2VzLzMzNDgvbGluZV9pdGVtcyIsImxpbmVpdGVtIjoiaHR0cHM6Ly91bmljb24uaW5zdHJ1Y3R1cmUuY29tL2FwaS9sdGkvY291cnNlcy8zMzQ4L2xpbmVfaXRlbXMvNTAzIiwidmFsaWRhdGlvbl9jb250ZXh0IjpudWxsLCJlcnJvcnMiOnsiZXJyb3JzIjp7fX19LCJwaWN0dXJlIjoiaHR0cHM6Ly9jYW52YXMuaW5zdHJ1Y3R1cmUuY29tL2ltYWdlcy9tZXNzYWdlcy9hdmF0YXItNTAucG5nIiwiZW1haWwiOiJtZ3dvemR6QHVuaWNvbi5uZXQiLCJuYW1lIjoiTWFyeSBHd296ZHoiLCJnaXZlbl9uYW1lIjoiTWFyeSIsImZhbWlseV9uYW1lIjoiR3dvemR6IiwiaHR0cHM6Ly9wdXJsLmltc2dsb2JhbC5vcmcvc3BlYy9sdGkvY2xhaW0vbGlzIjp7InBlcnNvbl9zb3VyY2VkaWQiOiJtZ3dvemR6IiwiY291cnNlX29mZmVyaW5nX3NvdXJjZWRpZCI6bnVsbCwidmFsaWRhdGlvbl9jb250ZXh0IjpudWxsLCJlcnJvcnMiOnsiZXJyb3JzIjp7fX19LCJodHRwczovL3B1cmwuaW1zZ2xvYmFsLm9yZy9zcGVjL2x0aS1ucnBzL2NsYWltL25hbWVzcm9sZXNlcnZpY2UiOnsiY29udGV4dF9tZW1iZXJzaGlwc191cmwiOiJodHRwczovL3VuaWNvbi5pbnN0cnVjdHVyZS5jb20vYXBpL2x0aS9jb3Vyc2VzLzMzNDgvbmFtZXNfYW5kX3JvbGVzIiwic2VydmljZV92ZXJzaW9ucyI6WyIyLjAiXSwidmFsaWRhdGlvbl9jb250ZXh0IjpudWxsLCJlcnJvcnMiOnsiZXJyb3JzIjp7fX19LCJodHRwczovL3d3dy5pbnN0cnVjdHVyZS5jb20vcGxhY2VtZW50IjpudWxsfQ.qN6MqcitF8VHuMVk_YmuXnKN43A1TgdjbSV8zHxT6SS5uZo8vtTB2GBGmqPpsknTmJPNijpQsPMoeLN3kKAvkpJ0RJPWMYud89a1SGnons8HuqXxACUCwUa7Lki8j7xSIXB6tgXQqzkrHCPmsBwLQy6rAYseiDNpsLkzIZzBAZjt89262i_UxRScJkhdPF4GEQDw4d2d1YMM5cmSy039BZZyT7AOV4q3qjo_BeFlQ5QJjXDtXGZ5VIcOuyLipAcrG8a2llXd8gLDkxkD0gIwI_zZX2fG-XKHc_co_gp45L2fVz09vKS5R-yCiooZgktOBoe0OEY8vHfCbBk4Vj2sxg";
+    private static final String SAMPLE_ISS = "https://platform-lms.com";
+    private static final String SAMPLE_CLIENT_ID = "sample-client-id";
+    private static final String SAMPLE_DEPLOYMENT_ID = "sample-deployment-id";
+
+    @Mock
+    private LTIDataService ltiDataService;
+
+    @InjectMocks
+    private AllRepositories allRepositories;
+
+    @Mock
+    private PlatformDeploymentRepository platformDeploymentRepository;
+
+    @Mock
+    private HttpServletRequest req;
+
+    @Mock
+    private PlatformDeployment platformDeployment;
+
+    @Mock
+    Jws<Claims> jwsClaims;
+
+    @Mock
+    Claims claims;
+
+    private List<PlatformDeployment> platformDeploymentList;
+
+    private MockHttpSession mockHttpSession = new MockHttpSession();
+
+    @Configuration
+    static class ContextConfiguration {
+
+    }
+
+    @BeforeEach()
+    public void setUp() throws Exception {
+        MockitoAnnotations.openMocks(this);
+        platformDeploymentList = Arrays.asList(platformDeployment);
+        when(ltiDataService.getRepos()).thenReturn(allRepositories);
+        when(jwsClaims.getBody()).thenReturn(claims);
+        when(req.getSession()).thenReturn(mockHttpSession);
+    }
+
+    @Test
+    public void testLTI3RequestWithoutRequest() {
+        AssertionError exception = Assertions.assertThrows(
+                AssertionError.class,
+                () -> {new LTI3Request(null, ltiDataService, false, "1234", jwsClaims);}
+        );
+        assertEquals(exception.getMessage(), "cannot make an LtiRequest without a request");
+    }
+
+    @Test
+    public void testLTI3RequestWithoutDataService() {
+        AssertionError exception = Assertions.assertThrows(
+                AssertionError.class,
+                () -> {new LTI3Request(req, null, false, "1234", jwsClaims);}
+        );
+        assertEquals(exception.getMessage(), "LTIDataService cannot be null");
+    }
+
+    @Test
+    public void testLTI3RequestWithoutDeployment() {
+        when(req.getParameter("id_token")).thenReturn(ID_TOKEN);
+        when(platformDeploymentRepository.findByIssAndClientIdAndDeploymentId(any(String.class), any(String.class), any(String.class))).thenReturn(new ArrayList<>());
+        when(claims.getIssuer()).thenReturn(SAMPLE_ISS);
+        when(claims.getAudience()).thenReturn(SAMPLE_CLIENT_ID);
+        when(claims.get(eq(LtiStrings.LTI_DEPLOYMENT_ID))).thenReturn(SAMPLE_DEPLOYMENT_ID);
+
+        IllegalStateException exception = Assertions.assertThrows(
+                IllegalStateException.class,
+                () -> {new LTI3Request(req, ltiDataService, false, "1234", jwsClaims);}
+        );
+        verify(platformDeploymentRepository).findByIssAndClientIdAndDeploymentId(any(String.class), any(String.class), any(String.class));
+        assertEquals("PlatformDeployment does not exist or is duplicated for issuer: https://platform-lms.com, clientId: sample-client-id, and deploymentId: sample-deployment-id", exception.getMessage());
+    }
+
+    @Test
+    public void testLTI3RequestWithDuplicateDeployment() {
+        when(req.getParameter("id_token")).thenReturn(ID_TOKEN);
+        when(platformDeploymentRepository.findByIssAndClientIdAndDeploymentId(any(String.class), any(String.class), any(String.class))).thenReturn(Arrays.asList(platformDeployment, platformDeployment));
+        when(claims.getIssuer()).thenReturn(SAMPLE_ISS);
+        when(claims.getAudience()).thenReturn(SAMPLE_CLIENT_ID);
+        when(claims.get(eq(LtiStrings.LTI_DEPLOYMENT_ID))).thenReturn(SAMPLE_DEPLOYMENT_ID);
+
+        IllegalStateException exception = Assertions.assertThrows(
+                IllegalStateException.class,
+                () -> {new LTI3Request(req, ltiDataService, false, "1234", jwsClaims);}
+        );
+        verify(platformDeploymentRepository).findByIssAndClientIdAndDeploymentId(any(String.class), any(String.class), any(String.class));
+        assertEquals("PlatformDeployment does not exist or is duplicated for issuer: https://platform-lms.com, clientId: sample-client-id, and deploymentId: sample-deployment-id", exception.getMessage());
+    }
+
+    @Test
+    public void testLTI3RequestWithInvalidMessageType() {
+        when(req.getParameter("id_token")).thenReturn(ID_TOKEN);
+        when(platformDeploymentRepository.findByIssAndClientIdAndDeploymentId(any(String.class), any(String.class), any(String.class))).thenReturn(platformDeploymentList);
+        when(claims.getIssuer()).thenReturn(SAMPLE_ISS);
+        when(claims.getAudience()).thenReturn(SAMPLE_CLIENT_ID);
+        when(claims.get(eq(LtiStrings.LTI_DEPLOYMENT_ID))).thenReturn(SAMPLE_DEPLOYMENT_ID);
+
+        IllegalStateException exception = Assertions.assertThrows(
+                IllegalStateException.class,
+                () -> {new LTI3Request(req, ltiDataService, false, "1234", jwsClaims);}
+        );
+        verify(platformDeploymentRepository).findByIssAndClientIdAndDeploymentId(any(String.class), any(String.class), any(String.class));
+        verify(claims).get(eq(LtiStrings.LTI_VERSION), eq(String.class));
+        verify(claims).get(eq(LtiStrings.LTI_MESSAGE_TYPE), eq(String.class));
+        assertEquals("Request is not a valid LTI3 request: LTI Version = null. LTI Message Type = null. ", exception.getMessage());
+    }
+
+    @Test
+    public void testLTI3RequestWithMissingNonce() {
+        when(req.getParameter("id_token")).thenReturn(ID_TOKEN);
+        when(platformDeploymentRepository.findByIssAndClientIdAndDeploymentId(any(String.class), any(String.class), any(String.class))).thenReturn(platformDeploymentList);
+        when(claims.getIssuer()).thenReturn(SAMPLE_ISS);
+        when(claims.getAudience()).thenReturn(SAMPLE_CLIENT_ID);
+        when(claims.get(eq(LtiStrings.LTI_DEPLOYMENT_ID))).thenReturn(SAMPLE_DEPLOYMENT_ID);
+        when(claims.get(eq(LtiStrings.LTI_VERSION), eq(String.class))).thenReturn(LtiStrings.LTI_VERSION_3);
+        when(claims.get(eq(LtiStrings.LTI_MESSAGE_TYPE), eq(String.class))).thenReturn(LtiStrings.LTI_MESSAGE_TYPE_RESOURCE_LINK);
+        mockHttpSession.setAttribute("lti_nonce", new ArrayList<String>());
+        when(claims.get(eq(LtiStrings.LTI_NONCE), eq(String.class))).thenReturn("5d04cb12f45df6ee373c42a1ca4cdbe08e2bfa8e5f7c662aca3f6560687fdc47");
+
+        IllegalStateException exception = Assertions.assertThrows(
+                IllegalStateException.class,
+                () -> {new LTI3Request(req, ltiDataService, false, "1234", jwsClaims);}
+        );
+        verify(platformDeploymentRepository).findByIssAndClientIdAndDeploymentId(any(String.class), any(String.class), any(String.class));
+        verify(claims).get(eq(LtiStrings.LTI_VERSION), eq(String.class));
+        verify(claims).get(eq(LtiStrings.LTI_MESSAGE_TYPE), eq(String.class));
+        verify(claims).get(eq(LtiStrings.LTI_NONCE), eq(String.class));
+        assertEquals("Nonce error: Nonce = null in the JWT or in the session.", exception.getMessage());
+    }
+
+    @Test
+    public void testLTI3RequestWithInvalidNonce() {
+        when(req.getParameter("id_token")).thenReturn(ID_TOKEN);
+        when(platformDeploymentRepository.findByIssAndClientIdAndDeploymentId(any(String.class), any(String.class), any(String.class))).thenReturn(platformDeploymentList);
+        when(claims.getIssuer()).thenReturn(SAMPLE_ISS);
+        when(claims.getAudience()).thenReturn(SAMPLE_CLIENT_ID);
+        when(claims.get(eq(LtiStrings.LTI_DEPLOYMENT_ID))).thenReturn(SAMPLE_DEPLOYMENT_ID);
+        when(claims.get(eq(LtiStrings.LTI_VERSION), eq(String.class))).thenReturn(LtiStrings.LTI_VERSION_3);
+        when(claims.get(eq(LtiStrings.LTI_MESSAGE_TYPE), eq(String.class))).thenReturn(LtiStrings.LTI_MESSAGE_TYPE_RESOURCE_LINK);
+        mockHttpSession.setAttribute("lti_nonce", Arrays.asList("5d04cb12f45df6ee373c42a1ca4cdbe08e2bfa8e5f7c662aca3f6560687fdc47"));
+        when(claims.get(eq(LtiStrings.LTI_NONCE), eq(String.class))).thenReturn("5d04cb12f45df6ee373c42a1ca4cdbe08e2bfa8e5f7c662aca3f6560687fdc47");
+
+        IllegalStateException exception = Assertions.assertThrows(
+                IllegalStateException.class,
+                () -> {new LTI3Request(req, ltiDataService, false, "1234", jwsClaims);}
+        );
+        verify(platformDeploymentRepository).findByIssAndClientIdAndDeploymentId(any(String.class), any(String.class), any(String.class));
+        verify(claims).get(eq(LtiStrings.LTI_VERSION), eq(String.class));
+        verify(claims).get(eq(LtiStrings.LTI_MESSAGE_TYPE), eq(String.class));
+        verify(claims).get(eq(LtiStrings.LTI_NONCE), eq(String.class));
+        assertEquals("Nonce error: Unknown or already used nonce.", exception.getMessage());
+    }
+
+    @Test
+    public void testLTI3RequestWithValidNonce() {
+        when(req.getParameter("id_token")).thenReturn(ID_TOKEN);
+        when(platformDeploymentRepository.findByIssAndClientIdAndDeploymentId(any(String.class), any(String.class), any(String.class))).thenReturn(platformDeploymentList);
+        when(claims.getIssuer()).thenReturn(SAMPLE_ISS);
+        when(claims.getAudience()).thenReturn(SAMPLE_CLIENT_ID);
+        when(claims.get(eq(LtiStrings.LTI_DEPLOYMENT_ID))).thenReturn(SAMPLE_DEPLOYMENT_ID);
+        when(claims.get(eq(LtiStrings.LTI_VERSION), eq(String.class))).thenReturn(LtiStrings.LTI_VERSION_3);
+        when(claims.get(eq(LtiStrings.LTI_MESSAGE_TYPE), eq(String.class))).thenReturn(LtiStrings.LTI_MESSAGE_TYPE_RESOURCE_LINK);
+        mockHttpSession.setAttribute("lti_nonce", Arrays.asList("5d04cb12f45df6ee373c42a1ca4cdbe08e2bfa8e5f7c662aca3f6560687fdc47"));
+        when(claims.get(eq(LtiStrings.LTI_NONCE), eq(String.class))).thenReturn("ba5938df7756a32ca3a4f89c40d88ff742651bc3ff417f6a4b7443f6f1e6a16c");
+
+        Assertions.assertThrows(NullPointerException.class, () -> {new LTI3Request(req, ltiDataService, false, "1234", jwsClaims);});
+
+        verify(platformDeploymentRepository).findByIssAndClientIdAndDeploymentId(any(String.class), any(String.class), any(String.class));
+        verify(claims).get(eq(LtiStrings.LTI_VERSION), eq(String.class));
+        verify(claims).get(eq(LtiStrings.LTI_MESSAGE_TYPE), eq(String.class));
+        verify(claims).get(eq(LtiStrings.LTI_NONCE), eq(String.class));
+    }
+}

--- a/src/test/java/net/unicon/lti/utils/lti/LtiOidcUtilsTest.java
+++ b/src/test/java/net/unicon/lti/utils/lti/LtiOidcUtilsTest.java
@@ -1,0 +1,103 @@
+package net.unicon.lti.utils.lti;
+
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.Jws;
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.impl.DefaultClaims;
+import net.unicon.lti.model.PlatformDeployment;
+import net.unicon.lti.model.lti.dto.LoginInitiationDTO;
+import net.unicon.lti.service.lti.LTIDataService;
+import net.unicon.lti.utils.TextConstants;
+import org.apache.commons.lang3.time.DateUtils;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mock;
+import org.mockito.MockedStatic;
+import org.mockito.Mockito;
+import org.mockito.MockitoAnnotations;
+import org.springframework.context.annotation.Configuration;
+
+import java.security.GeneralSecurityException;
+import java.security.KeyPair;
+import java.security.KeyPairGenerator;
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+import java.time.ZoneOffset;
+import java.util.Base64;
+import java.util.Calendar;
+import java.util.Collections;
+import java.util.Date;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.fail;
+import static org.mockito.Mockito.when;
+
+public class LtiOidcUtilsTest {
+    @Mock
+    LTIDataService ltiDataService;
+
+    @Mock
+    PlatformDeployment platformDeployment;
+
+    @Mock
+    LoginInitiationDTO loginInitiationDTO;
+
+    @Configuration
+    static class ContextConfiguration {
+
+    }
+
+    @BeforeEach()
+    public void setUp() {
+        MockitoAnnotations.openMocks(this);
+    }
+
+    @Test
+    public void testGenerateState() {
+        LocalDateTime currentLocalDate = LocalDateTime.now(ZoneId.of("Z"));
+        try (MockedStatic<LocalDateTime> topDateTimeUtilMock = Mockito.mockStatic(LocalDateTime.class)) {
+            KeyPairGenerator kpg = KeyPairGenerator.getInstance("RSA");
+            kpg.initialize(1024);
+            KeyPair kp = kpg.generateKeyPair();
+            Base64.Encoder encoder = Base64.getEncoder();
+            String privateKey = "-----BEGIN PRIVATE KEY-----\n" + encoder.encodeToString(kp.getPrivate().getEncoded()) + "\n-----END PRIVATE KEY-----\n";
+            when(ltiDataService.getOwnPrivateKey()).thenReturn(privateKey);
+            when(platformDeployment.getIss()).thenReturn("test-iss");
+            when(platformDeployment.getClientId()).thenReturn("client-id");
+            when(loginInitiationDTO.getIss()).thenReturn("test-iss");
+            when(loginInitiationDTO.getLoginHint()).thenReturn("login-hint");
+            when(loginInitiationDTO.getLtiMessageHint()).thenReturn("lti-message-hint");
+            when(loginInitiationDTO.getTargetLinkUri()).thenReturn("target-link-uri");
+            Map<String, String> authRequestMap = Collections.singletonMap("nonce", "nonce-value");
+            topDateTimeUtilMock.when(() -> LocalDateTime.now(ZoneId.of("Z"))).thenReturn(currentLocalDate);
+
+            String state = LtiOidcUtils.generateState(ltiDataService, authRequestMap, loginInitiationDTO, "client-id", "deployment-id");
+
+            // validate that ltiToken was signed using private key and contains expected payload
+            Jws<Claims> parsedLtiToken = Jwts.parser().setSigningKey(kp.getPublic()).parseClaimsJws(state);
+            assertEquals(TextConstants.DEFAULT_KID, parsedLtiToken.getHeader().get("kid"));
+            assertEquals("JWT", parsedLtiToken.getHeader().getType());
+            Claims ltiTokenClaims = parsedLtiToken.getBody();
+            assertEquals("ltiStarter", ltiTokenClaims.getIssuer());
+            assertEquals("test-iss", ltiTokenClaims.getSubject());
+            assertEquals("client-id", ltiTokenClaims.getAudience());
+            assertEquals("nonce-value", ltiTokenClaims.getId());
+            assertEquals("test-iss", ltiTokenClaims.get("original_iss"));
+            assertEquals("login-hint", ltiTokenClaims.get("loginHint"));
+            assertEquals("lti-message-hint", ltiTokenClaims.get("ltiMessageHint"));
+            assertEquals("target-link-uri", ltiTokenClaims.get("targetLinkUri"));
+            assertEquals("client-id", ltiTokenClaims.get("clientId"));
+            assertEquals("deployment-id", ltiTokenClaims.get("ltiDeploymentId"));
+            assertEquals("/oidc/login_initiations", ltiTokenClaims.get("controller"));
+            // Dates are equal to the nearest minute
+            assertEquals(DateUtils.round(Date.from(currentLocalDate.plusHours(1).toInstant(ZoneOffset.UTC)), Calendar.MINUTE), DateUtils.round(ltiTokenClaims.getExpiration(), Calendar.MINUTE));
+            assertEquals(DateUtils.round(Date.from(currentLocalDate.toInstant(ZoneOffset.UTC)), Calendar.MINUTE), DateUtils.round(ltiTokenClaims.getNotBefore(), Calendar.MINUTE));
+            assertEquals(DateUtils.round(Date.from(currentLocalDate.toInstant(ZoneOffset.UTC)), Calendar.MINUTE), DateUtils.round(ltiTokenClaims.getIssuedAt(), Calendar.MINUTE));
+
+        } catch (GeneralSecurityException e) {
+            fail("GeneralSecurityException should not be thrown.");
+        }
+    }
+
+}


### PR DESCRIPTION
Canvas only sends the iss and client_id for the login_initiation process. According to the LTI Core specification, the platform is only required to send the iss. As the code was written, it assumed that the client_id would be unique. However, in Canvas, it is possible to deploy a tool from within a course as opposed to within the Admin settings. This can be done across multiple courses, at which point there can be a variety of deployment_ids in the tool's database corresponding to a single set of iss + client_id. Therefore, it was problematic that the tool would return an error if more than one entry per client_id could be found in the database. Additionally, this means that the deployment_id cannot actually be verified until after the launch is complete because there is no way to truly know what the user's deployment_id is until that point, so that code had to be moved.