### PR TITLE
Make Postman LTI Advantage Demo Possible

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,8 @@ LTI 1.3 tool.
 ### Endpoints
 #### Accessible without an LMS:
 - Manage Deployment Configurations/Registrations: https://localhost:443/config/
-- JWKS: https://localhost:443/jwks/jwk  
+- JWKS: https://localhost:443/jwks/jwk
+- LTI Advantage Client Assertion: https://localhost:443/config/lti_advantage/client_assertion
 #### Only Accessible within an LMS:
 - Redirect & Target URI: https://localhost:443/lti3
 - OIDC Initiation: https://localhost:443/oidc/login_initiations

--- a/src/main/java/net/unicon/lti/controller/lti/ConfigurationController.java
+++ b/src/main/java/net/unicon/lti/controller/lti/ConfigurationController.java
@@ -15,12 +15,15 @@ package net.unicon.lti.controller.lti;
 import lombok.extern.slf4j.Slf4j;
 import net.unicon.lti.model.PlatformDeployment;
 import net.unicon.lti.repository.PlatformDeploymentRepository;
+import net.unicon.lti.service.lti.LTIJWTService;
 import net.unicon.lti.utils.TextConstants;
+import org.apache.commons.lang3.StringUtils;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Scope;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -29,10 +32,15 @@ import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestMethod;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.ResponseBody;
 
+import java.io.IOException;
+import java.security.GeneralSecurityException;
+import java.util.Collections;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 
 /**
@@ -46,6 +54,9 @@ import java.util.Optional;
 public class ConfigurationController {
     @Autowired
     PlatformDeploymentRepository platformDeploymentRepository;
+
+    @Autowired
+    LTIJWTService ltijwtService;
 
     @GetMapping(value = "/", produces = "application/json;")
     @ResponseBody
@@ -109,5 +120,25 @@ public class ConfigurationController {
 
         platformDeploymentRepository.saveAndFlush(platformDeploymentToChange);
         return new ResponseEntity<>(platformDeploymentToChange, HttpStatus.OK);
+    }
+
+    @RequestMapping(value = "/lti_advantage/client_assertion", method = RequestMethod.POST, consumes = {MediaType.APPLICATION_JSON_VALUE})
+    public ResponseEntity<Map<String, String>> generateClientAssertionJWT(@RequestBody Map<String, String> body) throws GeneralSecurityException, IOException {
+        if (StringUtils.isAnyBlank(body.get("iss"), body.get("client_id"), body.get("deployment_id"))) {
+            String errorMessage = "iss was " + body.get("iss") + ", client_id was " + body.get("client_id") + ", and deployment_id was " + body.get("deployment_id") + ". All values must be provided.";
+            log.error(errorMessage);
+            return new ResponseEntity<>(Collections.singletonMap("error", errorMessage), HttpStatus.BAD_REQUEST);
+        }
+        List<PlatformDeployment> platformDeploymentList = platformDeploymentRepository.findByIssAndClientIdAndDeploymentId(body.get("iss"), body.get("client_id"), body.get("deployment_id"));
+        if (platformDeploymentList.size() != 1) {
+            String errorMessage = "PlatformDeployment size was " + platformDeploymentList.size() + ". There should be exactly 1.";
+            log.error(errorMessage);
+            return new ResponseEntity<>(Collections.singletonMap("error", errorMessage), HttpStatus.BAD_REQUEST);
+        }
+        PlatformDeployment platformDeployment = platformDeploymentList.get(0);
+
+        String clientAssertionJWT = ltijwtService.generateStateOrClientAssertionJWT(platformDeployment);
+
+        return new ResponseEntity<>(Collections.singletonMap("client_assertion", clientAssertionJWT), HttpStatus.OK);
     }
 }

--- a/src/main/java/net/unicon/lti/service/lti/LTIJWTService.java
+++ b/src/main/java/net/unicon/lti/service/lti/LTIJWTService.java
@@ -13,5 +13,5 @@ public interface LTIJWTService {
 
     Jws<Claims> validateJWT(String jwt, String clientId);
 
-    String generateTokenRequestJWT(PlatformDeployment platformDeployment) throws GeneralSecurityException, IOException;
+    String generateStateOrClientAssertionJWT(PlatformDeployment platformDeployment) throws GeneralSecurityException, IOException;
 }

--- a/src/main/java/net/unicon/lti/service/lti/impl/AdvantageConnectorHelperImpl.java
+++ b/src/main/java/net/unicon/lti/service/lti/impl/AdvantageConnectorHelperImpl.java
@@ -48,7 +48,6 @@ import java.security.GeneralSecurityException;
 import java.util.Arrays;
 import java.util.List;
 
-import static org.springframework.http.MediaType.APPLICATION_JSON;
 import static org.springframework.http.MediaType.TEXT_HTML;
 
 @Service
@@ -187,7 +186,7 @@ public class AdvantageConnectorHelperImpl implements AdvantageConnectorHelper {
         // This is standard too
         map.add("client_assertion_type", "urn:ietf:params:oauth:client-assertion-type:jwt-bearer");
         //This is special (see the generateTokenRequestJWT method for more comments)
-        map.add("client_assertion", ltijwtService.generateTokenRequestJWT(platformDeployment));
+        map.add("client_assertion", ltijwtService.generateStateOrClientAssertionJWT(platformDeployment));
         //We need to pass the scope of the token, meaning, the service we want to allow with this token.
         map.add("scope", scope);
         return new HttpEntity<>(map, headers);
@@ -203,7 +202,7 @@ public class AdvantageConnectorHelperImpl implements AdvantageConnectorHelper {
         // This is standard too
         parameterJson.put("client_assertion_type", "urn:ietf:params:oauth:client-assertion-type:jwt-bearer");
         //This is special (see the generateTokenRequestJWT method for more comments)
-        parameterJson.put("client_assertion", ltijwtService.generateTokenRequestJWT(platformDeployment));
+        parameterJson.put("client_assertion", ltijwtService.generateStateOrClientAssertionJWT(platformDeployment));
         //We need to pass the scope of the token, meaning, the service we want to allow with this token.
         parameterJson.put("scope", scope);
         return new HttpEntity<>(parameterJson.toString(), headers);

--- a/src/main/java/net/unicon/lti/service/lti/impl/LTIJWTServiceImpl.java
+++ b/src/main/java/net/unicon/lti/service/lti/impl/LTIJWTServiceImpl.java
@@ -135,7 +135,7 @@ public class LTIJWTServiceImpl implements LTIJWTService {
      * This JWT will contain the token request
      */
     @Override
-    public String generateTokenRequestJWT(PlatformDeployment platformDeployment) throws GeneralSecurityException, IOException {
+    public String generateStateOrClientAssertionJWT(PlatformDeployment platformDeployment) throws GeneralSecurityException, IOException {
 
         Date date = new Date();
         Key toolPrivateKey = OAuthUtils.loadPrivateKey(ltiDataService.getOwnPrivateKey());
@@ -158,7 +158,7 @@ public class LTIJWTServiceImpl implements LTIJWTService {
                 .claim("jti", UUID.randomUUID().toString())  //This is an specific claim to ask for tokens.
                 .signWith(SignatureAlgorithm.RS256, toolPrivateKey)  //We sign it with our own private key. The platform has the public one.
                 .compact();
-        log.debug("Token Request: \n {} \n", state);
+        log.debug("Client Assertion JWT/State: \n {} \n", state);
         return state;
     }
 

--- a/src/test/java/net/unicon/lti/service/lti/AdvantageConnectorHelperTest.java
+++ b/src/test/java/net/unicon/lti/service/lti/AdvantageConnectorHelperTest.java
@@ -89,14 +89,14 @@ public class AdvantageConnectorHelperTest {
         try {
             PlatformDeployment platformDeployment = new PlatformDeployment();
             platformDeployment.setoAuth2TokenUrl("https://lms.com/oauth2/token");
-            when(ltijwtService.generateTokenRequestJWT(platformDeployment)).thenReturn("jwt");
+            when(ltijwtService.generateStateOrClientAssertionJWT(platformDeployment)).thenReturn("jwt");
             LTIToken ltiToken = new LTIToken();
             ResponseEntity<LTIToken> responseEntity = new ResponseEntity<>(ltiToken, HttpStatus.OK);
             when(restTemplate.postForEntity(anyString(), any(HttpEntity.class), eq(LTIToken.class))).thenReturn(responseEntity);
 
             LTIToken ltiTokenResponse = advantageConnectorHelper.getToken(platformDeployment, AGSScope.AGS_SCORES_SCOPE.getScope());
 
-            verify(ltijwtService).generateTokenRequestJWT(platformDeployment);
+            verify(ltijwtService).generateStateOrClientAssertionJWT(platformDeployment);
             verify(restTemplate).postForEntity(anyString(), any(HttpEntity.class), eq(LTIToken.class));
             assertEquals(ltiTokenResponse, ltiToken);
         } catch (Exception e) {
@@ -109,7 +109,7 @@ public class AdvantageConnectorHelperTest {
         try {
             PlatformDeployment platformDeployment = new PlatformDeployment();
             platformDeployment.setoAuth2TokenUrl("https://lms.com/oauth2/token");
-            when(ltijwtService.generateTokenRequestJWT(platformDeployment)).thenReturn("jwt");
+            when(ltijwtService.generateStateOrClientAssertionJWT(platformDeployment)).thenReturn("jwt");
             List<HttpMessageConverter<?>> messageConverters = Mockito.mock(ArrayList.class);
             when(restTemplate.getMessageConverters()).thenReturn(messageConverters);
             LTIToken ltiToken = new LTIToken();
@@ -120,7 +120,7 @@ public class AdvantageConnectorHelperTest {
 
             LTIToken ltiTokenResponse = advantageConnectorHelper.getToken(platformDeployment, AGSScope.AGS_SCORES_SCOPE.getScope());
 
-            verify(ltijwtService).generateTokenRequestJWT(platformDeployment);
+            verify(ltijwtService).generateStateOrClientAssertionJWT(platformDeployment);
             verify(messageConverters).add(converterArgumentCaptor.capture());
             MappingJackson2HttpMessageConverter converter = converterArgumentCaptor.getValue();
             assertTrue(converter.getSupportedMediaTypes().contains(MediaType.TEXT_HTML));
@@ -138,7 +138,7 @@ public class AdvantageConnectorHelperTest {
             ConnectionException exception = assertThrows(ConnectionException.class, () -> {
                 PlatformDeployment platformDeployment = new PlatformDeployment();
                 platformDeployment.setoAuth2TokenUrl("https://lms.com/oauth2/token");
-                when(ltijwtService.generateTokenRequestJWT(platformDeployment)).thenReturn("jwt");
+                when(ltijwtService.generateStateOrClientAssertionJWT(platformDeployment)).thenReturn("jwt");
                 LTIToken ltiToken = new LTIToken();
                 ResponseEntity<LTIToken> responseEntity = new ResponseEntity<>(ltiToken, HttpStatus.BAD_REQUEST);
                 when(restTemplate.postForEntity(anyString(), any(HttpEntity.class), eq(LTIToken.class))).thenReturn(responseEntity);
@@ -146,7 +146,7 @@ public class AdvantageConnectorHelperTest {
                 advantageConnectorHelper.getToken(platformDeployment, AGSScope.AGS_SCORES_SCOPE.getScope());
             });
 
-            verify(ltijwtService).generateTokenRequestJWT(any(PlatformDeployment.class));
+            verify(ltijwtService).generateStateOrClientAssertionJWT(any(PlatformDeployment.class));
             verify(restTemplate).postForEntity(anyString(), any(HttpEntity.class), eq(LTIToken.class));
             assertEquals("Can't get the token: " + HttpStatus.BAD_REQUEST.getReasonPhrase(), exception.getMessage());
         } catch (GeneralSecurityException | IOException e) {
@@ -160,13 +160,13 @@ public class AdvantageConnectorHelperTest {
             Exception exception = assertThrows(ConnectionException.class, () -> {
                 PlatformDeployment platformDeployment = new PlatformDeployment();
                 platformDeployment.setoAuth2TokenUrl("https://lms.com/oauth2/token");
-                when(ltijwtService.generateTokenRequestJWT(platformDeployment)).thenReturn("jwt");
+                when(ltijwtService.generateStateOrClientAssertionJWT(platformDeployment)).thenReturn("jwt");
                 when(restTemplate.postForEntity(anyString(), any(HttpEntity.class), eq(LTIToken.class))).thenReturn(null);
 
                 advantageConnectorHelper.getToken(platformDeployment, AGSScope.AGS_SCORES_SCOPE.getScope());
             });
 
-            verify(ltijwtService).generateTokenRequestJWT(any(PlatformDeployment.class));
+            verify(ltijwtService).generateStateOrClientAssertionJWT(any(PlatformDeployment.class));
             verify(restTemplate).postForEntity(anyString(), any(HttpEntity.class), eq(LTIToken.class));
             assertEquals(exception.getMessage(), "Problem getting the token");
         } catch (GeneralSecurityException | IOException e) {
@@ -180,11 +180,11 @@ public class AdvantageConnectorHelperTest {
             assertThrows(ConnectionException.class, () -> {
                 PlatformDeployment platformDeployment = new PlatformDeployment();
                 platformDeployment.setoAuth2TokenUrl("https://lms.com/oauth2/token");
-                when(ltijwtService.generateTokenRequestJWT(platformDeployment)).thenThrow(GeneralSecurityException.class);
+                when(ltijwtService.generateStateOrClientAssertionJWT(platformDeployment)).thenThrow(GeneralSecurityException.class);
 
                 advantageConnectorHelper.getToken(platformDeployment, AGSScope.AGS_SCORES_SCOPE.getScope());
             });
-            verify(ltijwtService).generateTokenRequestJWT(any(PlatformDeployment.class));
+            verify(ltijwtService).generateStateOrClientAssertionJWT(any(PlatformDeployment.class));
             verify(restTemplate, never()).postForEntity(anyString(), any(HttpEntity.class), eq(LTIToken.class));
             verify(exceptionMessageGenerator).exceptionMessage(eq("Can't get the token. Exception"), any(GeneralSecurityException.class));
         } catch (GeneralSecurityException | IOException e) {

--- a/src/test/postman/UniconDemoToolLTIAdvantage.postman_collection.json
+++ b/src/test/postman/UniconDemoToolLTIAdvantage.postman_collection.json
@@ -1,0 +1,355 @@
+{
+	"info": {
+		"_postman_id": "30c8ae14-57b6-43ed-bb0a-3090fb449b2f",
+		"name": "Unicon Demo Tool LTI Advantage",
+		"schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json",
+		"_exporter_id": "3873920"
+	},
+	"item": [
+		{
+			"name": "Step 0: POST for OAuth2 Client Assertion",
+			"event": [
+				{
+					"listen": "test",
+					"script": {
+						"exec": [
+							"let clientAssertion = pm.response.json().client_assertion;",
+							"pm.environment.set(\"client_assertion_jwt\", clientAssertion);",
+							"",
+							"pm.test(\"Has status 200\", () => {",
+							"    pm.response.to.have.status(200);",
+							"});"
+						],
+						"type": "text/javascript"
+					}
+				}
+			],
+			"request": {
+				"auth": {
+					"type": "basic",
+					"basic": [
+						{
+							"key": "password",
+							"value": "{{auth_password}}",
+							"type": "string"
+						},
+						{
+							"key": "username",
+							"value": "admin",
+							"type": "string"
+						}
+					]
+				},
+				"method": "POST",
+				"header": [],
+				"body": {
+					"mode": "raw",
+					"raw": "{\n    \"iss\": \"https://canvas.instructure.com\",\n    \"client_id\": \"97140000000000269\",\n    \"deployment_id\": \"526:5440a08422ab1ee7794a0588b5e4cb4a094c4256\"\n}",
+					"options": {
+						"raw": {
+							"language": "json"
+						}
+					}
+				},
+				"url": {
+					"raw": "{{middleware_url}}/config/lti_advantage/client_assertion",
+					"host": [
+						"{{middleware_url}}"
+					],
+					"path": [
+						"config",
+						"lti_advantage",
+						"client_assertion"
+					]
+				}
+			},
+			"response": []
+		},
+		{
+			"name": "Step 1: POST to LMS for OAuth2 Bearer Token Lineitem Scope",
+			"event": [
+				{
+					"listen": "test",
+					"script": {
+						"exec": [
+							"let accessToken = pm.response.json().access_token;",
+							"pm.environment.set(\"lti_adv_access_token\", accessToken);",
+							"",
+							"pm.test(\"Has status 200\", () => {",
+							"    pm.response.to.have.status(200);",
+							"});"
+						],
+						"type": "text/javascript"
+					}
+				}
+			],
+			"request": {
+				"method": "POST",
+				"header": [],
+				"body": {
+					"mode": "urlencoded",
+					"urlencoded": [
+						{
+							"key": "grant_type",
+							"value": "client_credentials",
+							"type": "text"
+						},
+						{
+							"key": "client_assertion_type",
+							"value": "urn:ietf:params:oauth:client-assertion-type:jwt-bearer",
+							"type": "text"
+						},
+						{
+							"key": "client_assertion",
+							"value": "{{client_assertion_jwt}}",
+							"type": "text"
+						},
+						{
+							"key": "scope",
+							"value": "https://purl.imsglobal.org/spec/lti-ags/scope/lineitem",
+							"type": "text"
+						}
+					]
+				},
+				"url": {
+					"raw": "https://canvas.unicon.net/login/oauth2/token",
+					"protocol": "https",
+					"host": [
+						"canvas",
+						"unicon",
+						"net"
+					],
+					"path": [
+						"login",
+						"oauth2",
+						"token"
+					]
+				}
+			},
+			"response": []
+		},
+		{
+			"name": "Step 2: GET Lineitems from LMS",
+			"request": {
+				"auth": {
+					"type": "bearer",
+					"bearer": [
+						{
+							"key": "token",
+							"value": "{{lti_adv_access_token}}",
+							"type": "string"
+						}
+					]
+				},
+				"method": "GET",
+				"header": [],
+				"url": {
+					"raw": "https://canvas.unicon.net/api/lti/courses/3623/line_items",
+					"protocol": "https",
+					"host": [
+						"canvas",
+						"unicon",
+						"net"
+					],
+					"path": [
+						"api",
+						"lti",
+						"courses",
+						"3623",
+						"line_items"
+					]
+				}
+			},
+			"response": []
+		},
+		{
+			"name": "Step 1: POST to LMS for OAuth2 Bearer Token Score Scope",
+			"event": [
+				{
+					"listen": "test",
+					"script": {
+						"exec": [
+							"let accessToken = pm.response.json().access_token;",
+							"pm.environment.set(\"lti_adv_access_token\", accessToken);",
+							"",
+							"pm.test(\"Has status 200\", () => {",
+							"    pm.response.to.have.status(200);",
+							"});"
+						],
+						"type": "text/javascript"
+					}
+				}
+			],
+			"request": {
+				"method": "POST",
+				"header": [],
+				"body": {
+					"mode": "urlencoded",
+					"urlencoded": [
+						{
+							"key": "grant_type",
+							"value": "client_credentials",
+							"type": "text"
+						},
+						{
+							"key": "client_assertion_type",
+							"value": "urn:ietf:params:oauth:client-assertion-type:jwt-bearer",
+							"type": "text"
+						},
+						{
+							"key": "client_assertion",
+							"value": "{{client_assertion_jwt}}",
+							"type": "text"
+						},
+						{
+							"key": "scope",
+							"value": "https://purl.imsglobal.org/spec/lti-ags/scope/score",
+							"type": "text"
+						}
+					]
+				},
+				"url": {
+					"raw": "https://canvas.unicon.net/login/oauth2/token",
+					"protocol": "https",
+					"host": [
+						"canvas",
+						"unicon",
+						"net"
+					],
+					"path": [
+						"login",
+						"oauth2",
+						"token"
+					]
+				}
+			},
+			"response": []
+		},
+		{
+			"name": "Step 2: POST Score to LMS",
+			"request": {
+				"auth": {
+					"type": "bearer",
+					"bearer": [
+						{
+							"key": "token",
+							"value": "{{lti_adv_access_token}}",
+							"type": "string"
+						}
+					]
+				},
+				"method": "POST",
+				"header": [],
+				"body": {
+					"mode": "raw",
+					"raw": "{\n    \"userId\": \"4999c972-7da9-40c8-afe6-3c278a9e5895\",\n    \"scoreGiven\": 75,\n    \"scoreMaximum\": 100,\n    \"activityProgress\": \"Completed\",\n    \"gradingProgress\": \"FullyGraded\",\n    \"comment\": \"Hello World\",\n    \"timestamp\": \"2022-10-12T18:54:36.736+00:00\"\n}",
+					"options": {
+						"raw": {
+							"language": "json"
+						}
+					}
+				},
+				"url": {
+					"raw": "https://canvas.unicon.net/api/lti/courses/3618/line_items/1177/scores",
+					"protocol": "https",
+					"host": [
+						"canvas",
+						"unicon",
+						"net"
+					],
+					"path": [
+						"api",
+						"lti",
+						"courses",
+						"3618",
+						"line_items",
+						"1177",
+						"scores"
+					]
+				}
+			},
+			"response": []
+		},
+		{
+			"name": "Step 1: POST to LMS for OAuth2 Bearer Token NRPS Scope",
+			"request": {
+				"method": "POST",
+				"header": [],
+				"body": {
+					"mode": "urlencoded",
+					"urlencoded": [
+						{
+							"key": "grant_type",
+							"value": "client_credentials",
+							"type": "text"
+						},
+						{
+							"key": "client_assertion_type",
+							"value": "urn:ietf:params:oauth:client-assertion-type:jwt-bearer",
+							"type": "text"
+						},
+						{
+							"key": "client_assertion",
+							"value": "eyJraWQiOiJPV05LRVkiLCJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiJ9.eyJpc3MiOiI5NzE0MDAwMDAwMDAwMDI2OSIsInN1YiI6Ijk3MTQwMDAwMDAwMDAwMjY5IiwiYXVkIjoiaHR0cHM6Ly9jYW52YXMudW5pY29uLm5ldC9sb2dpbi9vYXV0aDIvdG9rZW4iLCJleHAiOjE2NjU2OTY3MjUsIm5iZiI6MTY2NTY5MzEyNSwiaWF0IjoxNjY1NjkzMTI1LCJqdGkiOiIwNTA4MTg2Yy01ZTA2LTQwNWYtOTBmYy1hM2NiMDMzMDVlYmYifQ.KriNrXn4HMokkcPLCjt91uF4L6uIiNy9SD5q8WBsxxGihvSiTdIOVEoJYm_kk2xLeQt0hBSuRg9cA5d7D1yXcRl4R16W3y9Vz6i9-cqlBV2M9CsiUrRvARWi8GtIs9o3CYcJTypV1AUigt4hZG5KohTBwCIat7TqfMI4za1CmjefmqNlIdCjrHIybkWMh0Sc0ePdVObv_JsOUt3HPWo_URXo25ExzD0bFNJC6K2JMPkVCqV6Sc0qn6uHWmeZ84AoJvXf2UneYoqwSPWH8reHP3fmfZDvA7WAUV26NjD5QVGfiVF4kmOXTcuMKspRnssTgbPEBGHJvE6FtoXmtxjxfg",
+							"type": "text"
+						},
+						{
+							"key": "scope",
+							"value": "https://purl.imsglobal.org/spec/lti-nrps/scope/contextmembership.readonly",
+							"type": "text"
+						}
+					]
+				},
+				"url": {
+					"raw": "https://canvas.unicon.net/login/oauth2/token",
+					"protocol": "https",
+					"host": [
+						"canvas",
+						"unicon",
+						"net"
+					],
+					"path": [
+						"login",
+						"oauth2",
+						"token"
+					]
+				}
+			},
+			"response": []
+		},
+		{
+			"name": "Step 2: GET Memberships",
+			"request": {
+				"auth": {
+					"type": "bearer",
+					"bearer": [
+						{
+							"key": "token",
+							"value": "eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJpc3MiOiJodHRwczovL2NhbnZhcy5pbnN0cnVjdHVyZS5jb20iLCJzdWIiOiI5NzE0MDAwMDAwMDAwMDI2OSIsImF1ZCI6Imh0dHBzOi8vY2FudmFzLnVuaWNvbi5uZXQvbG9naW4vb2F1dGgyL3Rva2VuIiwiaWF0IjoxNjY1NjkzMTQ2LCJleHAiOjE2NjU2OTY3NDYsImp0aSI6IjM4YjMyMDgyLTA3ODMtNDg2Yi1iMWM5LTNiY2JlYzkxODcwYyIsInNjb3BlcyI6Imh0dHBzOi8vcHVybC5pbXNnbG9iYWwub3JnL3NwZWMvbHRpLW5ycHMvc2NvcGUvY29udGV4dG1lbWJlcnNoaXAucmVhZG9ubHkiLCJjYW52YXMuaW5zdHJ1Y3R1cmUuY29tIjp7ImFjY291bnRfdXVpZCI6InBvdDI4eU5wRFNaczFGdk1RYTQyTWlQV2xST0xRQ0FlZHpRWDZNYzIifX0.UZKj7YSXRf1zI-bvsA9UNy3-2dv57yM6uWP1XZdYjm8",
+							"type": "string"
+						}
+					]
+				},
+				"method": "GET",
+				"header": [],
+				"url": {
+					"raw": "https://canvas.unicon.net/api/lti/courses/3623/names_and_roles",
+					"protocol": "https",
+					"host": [
+						"canvas",
+						"unicon",
+						"net"
+					],
+					"path": [
+						"api",
+						"lti",
+						"courses",
+						"3623",
+						"names_and_roles"
+					]
+				}
+			},
+			"response": []
+		}
+	]
+}


### PR DESCRIPTION
Made it possible to test the LTI Advantage services via Postman by adding an endpoint for generating the client_assertion JWT that has to be included in the OAuth2 Token Requests to retrieve the bearer token to use the LTI Advantage services. I placed this endpoint inside the ConfigurationController so that it would have some auth behind it since this endpoint should probably be removed from production instances for security purposes. However, I think it will be extremely helpful for demonstration purposes. I included a Postman Collection that will perform these demonstrations.
I also changed the name of the method that generates the client_assertion JWT as well as the logging to try to make that clearer.