### PR TITLE
Schoology fixes

### DIFF
--- a/src/main/java/net/unicon/lti/model/ags/Score.java
+++ b/src/main/java/net/unicon/lti/model/ags/Score.java
@@ -24,7 +24,7 @@ public class Score {
     @JsonProperty("scoreGiven")
     private String scoreGiven;
     @JsonProperty("comment")
-    private String comment;
+    private String comment; // NOTE: Schoology requires this to be a non-null value. It may be whitespace.
     @JsonProperty("activityProgress")
     private String activityProgress;
     @JsonProperty("gradingProgress")

--- a/src/main/java/net/unicon/lti/service/lti/impl/AdvantageMembershipServiceImpl.java
+++ b/src/main/java/net/unicon/lti/service/lti/impl/AdvantageMembershipServiceImpl.java
@@ -66,7 +66,7 @@ public class AdvantageMembershipServiceImpl implements AdvantageMembershipServic
         try {
             RestTemplate restTemplate = advantageConnectorHelper.createRestTemplate();
             //We add the token in the request with this.
-            HttpEntity request = advantageConnectorHelper.createTokenizedRequestEntity(LTIToken);
+            HttpEntity request = advantageConnectorHelper.createTokenizedRequestEntity(LTIToken, "application/vnd.ims.lti-nrps.v2.membershipcontainer+json"); // Note: Schoology requires correct accept type
             //The URL to get the course contents is stored in the context (in our database) because it came
             // from the platform when we created the link to the context, and we saved it then.
             final String GET_MEMBERSHIP = context.getContext_memberships_url();


### PR DESCRIPTION
- Handle array audience
- Use nrps accept type
- Note that score comment must be non-null

It is also noteworthy that while AGS works fully from an API perspective, Schoology requires each assignment to have a "Category" associated with it in order for the assignment to be visible in the gradebook UI. Pearson documented their workaround here, instructing teachers on how to add the category manually for each assignment: https://help.pearsoncmg.com/integration/cg/instructor/content/get_started-schoology-13.htm